### PR TITLE
Fix Docker workflow branch detection and Azure pipeline target

### DIFF
--- a/.github/azure/azure-pipelines.yml
+++ b/.github/azure/azure-pipelines.yml
@@ -18,10 +18,7 @@ variables:
   - group: arc_iasc
 
   - name: appName
-    ${{ if eq( variables['Build.SourceBranchName'], 'release' ) }}:
-      value: 'duuksawharciasc01'
-    ${{ if ne( variables['Build.SourceBranchName'], 'release' ) }}:
-      value: 'duuksawharciascdevel01'
+    value: 'duuksawharciasc01'
     
   - name: azureSubscription
     value: 'svc-con-awh-01'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Add SHORT_SHA and BRANCH to env
         run: |
           echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV \
-          && echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
+          && echo "BRANCH=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
## Summary

- Fix `BRANCH` env var in `docker.yml`: under `workflow_run`, `GITHUB_REF` points to the workflow file's ref (main), not the triggering branch. Now uses `github.event.workflow_run.head_branch` correctly.
- Remove branch conditional from `azure-pipelines.yml`: the devel app service (`duuksawharciascdevel01`) no longer exists. Pipeline always deploys to `duuksawharciasc01`.