### PR TITLE
Fix Docker build: copy survey_definitions.json into build_node stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN npm install
 
 # Copy files and build app
 ADD react-app /app/react-app
+COPY survey_definitions.json /app/survey_definitions.json
 WORKDIR /app/react-app
 RUN npm run webpack
 


### PR DESCRIPTION
## Summary

- Fixes the Docker build failure introduced by the data-driven survey definitions work
- `survey_definitions.json` lives at the repo root but was not being copied into the `build_node` stage, so webpack could not resolve the `../../survey_definitions.json` import from `react-app/src/`

## Test plan

- [ ] Docker build completes successfully
- [ ] Deployed app loads survey definitions correctly for all types (LI, L2E, L3C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)