### PR TITLE
Fix ADO pipeline: declare commitHash variable for runtime override

### DIFF
--- a/.github/azure/azure-pipelines.yml
+++ b/.github/azure/azure-pipelines.yml
@@ -25,6 +25,10 @@ variables:
   - name: resourceGroupName
     value: 'du-uks-awh-arc-iasc01'
 
+  # Passed at runtime by docker.yml via Azure/pipelines action
+  - name: commitHash
+    value: ''
+
   # Azure container registry connection details
   - name: dockerRegistryServiceConnection
     value: 'duuksawhacr01.azurecr.io'


### PR DESCRIPTION
## Summary

- ADO rejects builds that pass undeclared runtime variables — declare `commitHash` with an empty default so `docker.yml` can pass the correct release HEAD SHA
- Also fixes `azure-pipeline-variables` input name in `docker.yml` (was incorrectly `variables`)
- Switches Docker layer cache from GHA cache to ACR registry cache (more reliable for multi-platform builds)