### PR TITLE
Fix Unit tests firing on Azure Pipeline change

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,7 +4,7 @@ on:
     paths:
       - 'iasc/**/*'
       - 'frontend/**/*'
-      - '.github/workflows/*'
+      - '.github/*'
       - 'Dockerfile'
       - 'conf/**/*'
   pull_request:


### PR DESCRIPTION
## Summary

- Unit tests do not fire on PR merge when only pipeline has changed. Updated behaviour to fire on any workflow under `.github/`