### PR TITLE
Refactor CI/CD: decouple unit tests from Docker build trigger

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,29 +2,21 @@
 name: Build Docker Images
 
 on:
-  workflow_run:
-    workflows:
-      - Unit Tests
+  push:
     branches:
       - release
-    types:
-      - completed
 
 env:
   DOCKERHUB_REPO: ${{ secrets.AZURE_ACR_REGISTRY }}/arc/iasc
 
 jobs:
   docker:
-    if: github.event.workflow_run.conclusion == 'success'
-
     runs-on: ubuntu-latest
     outputs:
       short_sha: ${{ steps.sha.outputs.short_sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: release
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
@@ -43,7 +35,7 @@ jobs:
         run: |
           echo "SHORT_SHA=$(git rev-parse --short=8 HEAD)" >> $GITHUB_ENV \
           && echo "short_sha=$(git rev-parse --short=8 HEAD)" >> $GITHUB_OUTPUT \
-          && echo "BRANCH=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_ENV
+          && echo "BRANCH=release" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -66,8 +58,6 @@ jobs:
     name: Release to Azure Pipelines Production
     needs: docker
     runs-on: ubuntu-latest
-
-    if: github.event.workflow_run.head_branch == 'release'
 
     steps:
       - name: Azure Pipelines Action

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,12 +1,12 @@
 name: Unit Tests
 on:
   push:
+    branches-ignore:
+      - release
     paths:
       - 'iasc/**/*'
       - 'frontend/**/*'
-      - '.github/*'
-      - 'Dockerfile'
-      - 'conf/**/*'
+      - '.github/workflows/*'
   pull_request:
     types:
       - opened


### PR DESCRIPTION
## Summary

- Docker build now triggers directly on `push` to `release`, removing the fragile `workflow_run` chain
- Unit tests no longer run on push to `release` — release is PR-only, so tests already passed before merge
- Unit test push trigger restored to original scope: `iasc/`, `frontend/`, `.github/workflows/` on non-release branches only
- `pull_request` trigger unchanged — unit tests still run on all PRs regardless of target branch

## Test plan

- [ ] Merge and confirm Docker build triggers directly on push to `release`
- [ ] Confirm unit tests do not re-run on merge to `release`
- [ ] Confirm unit tests still run on PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)