### PR TITLE
Revert: remove commitHash variable declaration from ADO pipeline

### DIFF
--- a/.github/azure/azure-pipelines.yml
+++ b/.github/azure/azure-pipelines.yml
@@ -25,10 +25,6 @@ variables:
   - name: resourceGroupName
     value: 'du-uks-awh-arc-iasc01'
 
-  # Passed at runtime by docker.yml via Azure/pipelines action
-  - name: commitHash
-    value: ''
-
   # Azure container registry connection details
   - name: dockerRegistryServiceConnection
     value: 'duuksawhacr01.azurecr.io'


### PR DESCRIPTION
## Summary

Reverts a382903. The `commitHash` variable declaration with an empty default was causing `DOCKER_CUSTOM_IMAGE_NAME` to be set without a tag. The variable will be configured in the Azure DevOps web UI instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)