### PR TITLE
Validate voting token on poll page load (closes #71)

### DIFF
--- a/iasc/tests.py
+++ b/iasc/tests.py
@@ -900,3 +900,25 @@ class DatabaseModelTestCase(TestCase):
         )
         with self.assertRaises(DjangoValidationError):
             survey.full_clean()
+
+    def test_token_validation_valid(self):
+        """GET /api/vote/{token}/ returns 200 for an existing (unused) token."""
+        link = ActiveLink.objects.get()
+        resp = self.client.get(f"/api/vote/{link.unique_link}/")
+        self.assertEqual(resp.status_code, 200)
+        import json as json_mod
+
+        data = json_mod.loads(resp.content)
+        self.assertEqual(data["status"], "valid")
+
+    def test_token_validation_used_or_missing(self):
+        """GET /api/vote/{token}/ returns 404 for a missing or already-used token."""
+        resp = self.client.get("/api/vote/nonexistent-token-xyz/")
+        self.assertEqual(resp.status_code, 404)
+
+        # Use the link and check again
+        link = ActiveLink.objects.get()
+        uid = link.unique_link
+        link.vote(3)
+        resp = self.client.get(f"/api/vote/{uid}/")
+        self.assertEqual(resp.status_code, 404)

--- a/iasc/views.py
+++ b/iasc/views.py
@@ -228,6 +228,24 @@ class SubmitVoteView(ViewSet):
 
     permission_classes = (permissions.AllowAny,)
 
+    def retrieve(self, request, pk=None):
+        """Check whether a token is still valid (i.e. has not yet been used)."""
+        if not pk:
+            return Response(
+                {"status": "error", "message": "No token provided"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        exists = ActiveLink.objects.filter(unique_link=pk.strip()).exists()
+        if exists:
+            return Response({"status": "valid"}, status=status.HTTP_200_OK)
+        return Response(
+            {
+                "status": "error",
+                "message": "This voting link has already been used or does not exist.",
+            },
+            status=status.HTTP_404_NOT_FOUND,
+        )
+
     def create(self, request):
         try:
             request_has_keys(request, {"unique_id", "vote"})

--- a/react-app/src/pages/survey/Survey.jsx
+++ b/react-app/src/pages/survey/Survey.jsx
@@ -22,6 +22,7 @@ export default function Poll() {
   const [surveyKind, setSurveyKind] = useState("LI");
   const [surveyQuestions, setSurveyQuestions] = useState(null);
   const [hideTitle, setHideTitle] = useState(false);
+  const [tokenUsed, setTokenUsed] = useState(false);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -45,15 +46,48 @@ export default function Poll() {
         } else {
           // Survey does not exist, redirect to the error page
           history("/error");
+          return;
         }
       } catch (error) {
         // Handle error and redirect to the error page
         history("/error");
+        return;
+      }
+
+      // Validate the token. A 404 means it has already been used (or never existed).
+      try {
+        await client.get(`/api/vote/${uniqueId}/`);
+      } catch (error) {
+        if (error.response?.status === 404) {
+          setTokenUsed(true);
+        } else {
+          history("/error");
+        }
       }
     };
 
     fetchData();
-  }, [surveyId, history]);
+  }, [surveyId, uniqueId, history]);
+
+  if (tokenUsed) {
+    return (
+      <div className="poll--total">
+        <div className="background-blur" />
+        <div className="background-blur mirror" />
+        <div className="poll">
+          <div className="poll--box">
+            <div className="poll--blurb">
+              This voting link has already been used.
+            </div>
+            <div className="poll--question">
+              If you believe this is an error, please contact the survey
+              administrator.
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="poll--total">


### PR DESCRIPTION
## Summary

- Adds `GET /api/vote/{token}/` endpoint on `SubmitVoteView.retrieve` — returns `200 {"status": "valid"}` if the token exists, `404` if it has been used or never existed
- `Survey.jsx` now validates the token immediately after loading survey data; if the token is invalid/used, it renders a clear "This voting link has already been used." message instead of showing the form
- All non-existent tokens are treated as used (consistent with the privacy design — ActiveLinks are destroyed on vote, so we cannot distinguish "used" from "never existed")
- Two new unit tests cover the valid-token and used/missing-token cases

## Test plan

- [ ] Run `DJANGO_SETTINGS_MODULE=iasc.settings python -m pytest iasc/tests.py -x -q` — all tests pass
- [ ] Load `/poll?survey=<id>&unique_id=<valid_token>` — survey form renders normally
- [ ] Load `/poll?survey=<id>&unique_id=<used_or_bogus_token>` — "already used" message is shown, no form
- [ ] Submit a vote on a valid token, then revisit the same URL — "already used" message is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)