### PR TITLE
Fix 500 on /api/survey/results/ for orphaned results (closes #80)

### DIFF
--- a/iasc/views.py
+++ b/iasc/views.py
@@ -405,7 +405,7 @@ class SurveyViewSet(viewsets.ReadOnlyModelViewSet):
 
 class SurveyResultsViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
-    queryset = Result.objects.distinct("survey_id")
+    queryset = Result.objects.filter(survey__isnull=False).distinct("survey_id")
 
     pagination_class = None
     serializer_class = serializers.SurveyResultSerializer


### PR DESCRIPTION
## Summary
- `/api/survey/results/` returns 500 when any `Result` row has a NULL `survey` FK (from a deleted survey, via `on_delete=SET_NULL`)
- The `SurveyResultSerializer` assumes `obj.survey` is non-null when accessing `survey.id`, `survey.question`, etc.
- Fix: filter out orphaned results with `.filter(survey__isnull=False)` in the `SurveyResultsViewSet` queryset

## Root cause
Confirmed via Azure container logs on instance P (`al0mdlwk00001P`):
```
AttributeError: 'NoneType' object has no attribute 'id'
  File "/app/iasc/views.py", line 417, in list
```
