### PR TITLE
Release: fix survey results 500 error (#80)

### DIFF
--- a/iasc/views.py
+++ b/iasc/views.py
@@ -405,7 +405,7 @@ class SurveyViewSet(viewsets.ReadOnlyModelViewSet):
 
 class SurveyResultsViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
-    queryset = Result.objects.distinct("survey_id")
+    queryset = Result.objects.filter(survey__isnull=False).distinct("survey_id")
 
     pagination_class = None
     serializer_class = serializers.SurveyResultSerializer


### PR DESCRIPTION
## Summary
- Merges main into release to deploy fix for #80 (500 on `/api/survey/results/` due to orphaned results with NULL survey FK)
