### PR TITLE
Fix pie chart vote labels being back to front

### DIFF
--- a/react-app/src/components/PieChart.jsx
+++ b/react-app/src/components/PieChart.jsx
@@ -7,22 +7,14 @@ import definitions from "../surveyDefinitions";
 ChartJS.register(ArcElement, Tooltip, Legend);
 
 const VOTE_LABELS = {
-  0: "Strongly Disagree",
-  1: "Disagree",
-  2: "Slightly Disagree",
-  3: "Slightly Agree",
-  4: "Agree",
-  5: "Strongly Agree",
+  1: "Strongly Agree",
+  2: "Agree",
+  3: "Neutral",
+  4: "Disagree",
+  5: "Strongly Disagree",
 };
 
-const COLORS = [
-  "#C0392B",
-  "#E74C3C",
-  "#E59866",
-  "#82E0AA",
-  "#27AE60",
-  "#1A5276",
-];
+const COLORS = ["#999", "#1A5276", "#27AE60", "#F4D03F", "#E59866", "#C0392B"];
 
 const PIE_OPTIONS = {
   plugins: {


### PR DESCRIPTION
## Summary

- `VOTE_LABELS` and `COLORS` in `PieChart.jsx` assumed `0=Strongly Disagree / 5=Strongly Agree`, but the voting form (`SurveyForm.jsx`) stores `5=Strongly Disagree / 1=Strongly Agree`
- Corrected the labels and semantic colours to match what is actually stored in the database

Closes #95