### PR TITLE
Dashboard CSS improvements: mobile layout, self-hosted icons, responsive fixes

### DIFF
--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -5,7 +5,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="C-SCOPE: The Centre for Scientific Community Opinion Polling and Evaluation" />
-    <meta name="viewport" content="width=device-width, user-scalable=no">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" />
     <title>C-SCOPE</title>
 </head>

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -5,8 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="C-SCOPE: The Centre for Scientific Community Opinion Polling and Evaluation" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" />
-    <title>C-SCOPE</title>
+<title>C-SCOPE</title>
 </head>
 <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/react-app/package-lock.json
+++ b/react-app/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.12.0",
         "chart.js": "^4.4.9",
+        "material-symbols": "^0.44.0",
         "react": "^18.3.1",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.3.1",
@@ -5666,6 +5667,12 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/material-symbols": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/material-symbols/-/material-symbols-0.44.0.tgz",
+      "integrity": "sha512-/wbn6EsheHQUOyQZHag4p0lcuAYCNzmgAhuGTpseh63C5Rc7FtWRRQviQiafvwA9tje1DLD83LVqGsCOX72H8w==",
+      "license": "Apache-2.0"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "axios": "^1.12.0",
     "chart.js": "^4.4.9",
+    "material-symbols": "^0.44.0",
     "react": "^18.3.1",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.3.1",

--- a/react-app/public/index.html
+++ b/react-app/public/index.html
@@ -15,10 +15,6 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
-    />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/react-app/src/components/DashboardTable.jsx
+++ b/react-app/src/components/DashboardTable.jsx
@@ -128,14 +128,14 @@ function DashboardTable({ reload, selectedSurveyId, onSelect }) {
       <table className="dashboard--question--table">
         <thead>
           <tr>
-            <th className="no-mobile">Statement</th>
+            <th className="no-mobile no-tablet">Statement</th>
             <th>ID</th>
             <th className="no-mobile">Type</th>
             <th>Completed</th>
             <th className="no-mobile">Links</th>
             <th>Expiry</th>
             <th>Active</th>
-            <th className="no-mobile">Results</th>
+            <th className="no-mobile no-tablet">Results</th>
           </tr>
         </thead>
         <tbody>
@@ -150,7 +150,7 @@ function DashboardTable({ reload, selectedSurveyId, onSelect }) {
                 )
               }
             >
-              <td className="no-mobile">
+              <td className="no-mobile no-tablet">
                 {row.question.substring(0, 50)}
                 {row.question.length > 50 && "..."}
               </td>
@@ -176,7 +176,7 @@ function DashboardTable({ reload, selectedSurveyId, onSelect }) {
                   }}
                 />
               </td>
-              <td className="no-mobile">
+              <td className="no-mobile no-tablet">
                 <a href={`/api/result/xls/?survey=${row.id}`}>
                   <span className="material-symbols-outlined">download</span>
                 </a>

--- a/react-app/src/components/PieChart.jsx
+++ b/react-app/src/components/PieChart.jsx
@@ -54,7 +54,12 @@ function buildCheckboxChartData(counts) {
 function SinglePie({ title, chartData }) {
   return (
     <div
-      style={{ width: "300px", textAlign: "center", marginBottom: "1.5rem" }}
+      style={{
+        width: "100%",
+        maxWidth: "300px",
+        textAlign: "center",
+        marginBottom: "1.5rem",
+      }}
     >
       <p
         style={{
@@ -113,7 +118,14 @@ function PieChart({ surveyId, fallbackQuestion }) {
 
   if (!hasResults) {
     return (
-      <div style={{ width: "300px", textAlign: "center", padding: "1rem" }}>
+      <div
+        style={{
+          width: "100%",
+          maxWidth: "300px",
+          textAlign: "center",
+          padding: "1rem",
+        }}
+      >
         <p style={{ fontWeight: "bold", marginBottom: "0.5rem" }}>{title}</p>
         <p style={{ color: "#999" }}>No results yet</p>
         <p style={{ color: "#999", fontSize: "0.8rem", marginTop: "0.5rem" }}>
@@ -132,7 +144,14 @@ function PieChart({ surveyId, fallbackQuestion }) {
     const dbStatements = survey.questions ?? [];
     let likertIdx = 0;
     return (
-      <div style={{ width: "300px", textAlign: "center", padding: "0.5rem" }}>
+      <div
+        style={{
+          width: "100%",
+          maxWidth: "300px",
+          textAlign: "center",
+          padding: "0.5rem",
+        }}
+      >
         <p style={{ fontWeight: "bold", marginBottom: "1rem" }}>{title}</p>
         {slots.map((slot) => {
           if (slot.type === "likert") {
@@ -168,7 +187,7 @@ function PieChart({ surveyId, fallbackQuestion }) {
   }
 
   return (
-    <div style={{ width: "300px", textAlign: "center" }}>
+    <div style={{ width: "100%", maxWidth: "300px", textAlign: "center" }}>
       <p style={{ fontWeight: "bold", marginBottom: "0.5rem" }}>{title}</p>
       <Pie data={buildLikertChartData(voteCounts)} options={PIE_OPTIONS} />
       <p style={{ color: "#999", fontSize: "0.8rem", marginTop: "0.5rem" }}>

--- a/react-app/src/index.jsx
+++ b/react-app/src/index.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./styles/global.css";
+import "material-symbols/outlined.css";
 
 const container = document.getElementById("root");
 const root = createRoot(container);

--- a/react-app/src/pages/dashboard/dashboard.css
+++ b/react-app/src/pages/dashboard/dashboard.css
@@ -671,27 +671,44 @@ input[type="file"][value]:not([value=""]) {
 }
 
 @media (max-width: 768px) {
+  .dashboard {
+    flex-direction: column;
+    padding: 1rem;
+  }
+
   .dashboard--overview {
-    display: none !important;
+    width: 100%;
+    order: -1;
   }
+
+  .dashboard--overview--content {
+    width: 100%;
+  }
+
   .dashboard--projects {
-    width: 100vw;
+    width: 100%;
   }
+
   .dashboard--question--table {
-    width: 100vw;
+    width: 100%;
   }
+
   .dashboard--question--entry {
     width: 10vw;
   }
+
   .no-mobile {
     display: none;
   }
+
   .dashboard--overview-active-box {
     width: 90vw;
   }
+
   .filter-button {
     width: 30vw;
   }
+
   .dashboard--next--page span {
     width: 30vw;
     padding: 1rem;

--- a/react-app/src/pages/dashboard/dashboard.css
+++ b/react-app/src/pages/dashboard/dashboard.css
@@ -46,6 +46,7 @@
   flex: 1 1 0;
   padding: 0;
   min-width: 0;
+  display: flex;
 }
 
 .dashboard--projects {
@@ -345,7 +346,7 @@
   width: 100%;
   display: flex;
   flex-direction: row;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
   margin-top: 1rem;
 }
@@ -725,6 +726,12 @@ input[type="file"][value]:not([value=""]) {
 
   .filter-button {
     width: 30vw;
+  }
+
+  .dashboard--table-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
   }
 
   .dashboard--next--page {

--- a/react-app/src/pages/dashboard/dashboard.css
+++ b/react-app/src/pages/dashboard/dashboard.css
@@ -516,15 +516,6 @@
   background-color: green;
 }
 
-.material-symbols-outlined {
-  font-family: "Material Symbols Outlined", sans-serif;
-  font-size: 24px;
-  width: 24px;
-  height: 24px;
-  display: inline-block;
-  overflow: hidden;
-}
-
 .next-step {
   display: flex;
   flex-direction: column;

--- a/react-app/src/pages/dashboard/dashboard.css
+++ b/react-app/src/pages/dashboard/dashboard.css
@@ -713,4 +713,15 @@ input[type="file"][value]:not([value=""]) {
     width: 30vw;
     padding: 1rem;
   }
+
+  .dashboard--button {
+    height: auto;
+    padding: 1.5rem 1rem;
+    font-size: 1.2rem;
+  }
+
+  .create-add-container {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
 }

--- a/react-app/src/pages/dashboard/dashboard.css
+++ b/react-app/src/pages/dashboard/dashboard.css
@@ -442,6 +442,10 @@
 }
 
 @media (max-width: 768px) {
+  .create-container {
+    padding: 1rem 1.5rem 2rem 1.5rem;
+  }
+
   .create-container.checkbox {
     width: 100%;
   }
@@ -569,8 +573,10 @@
 .add-participants-container {
   background-color: #fff;
   border: 2px solid #b8bcc5;
-  width: 500px;
-  height: 660px;
+  width: min(500px, 90vw);
+  height: auto;
+  max-height: 90vh;
+  overflow-y: auto;
   padding: 2rem;
   display: flex;
   flex-direction: column;
@@ -666,7 +672,8 @@ input[type="file"][value]:not([value=""]) {
 }
 
 .add-participants-input {
-  width: 350px;
+  width: 100%;
+  max-width: 350px;
   margin: 10px;
 }
 

--- a/react-app/src/pages/dashboard/dashboard.css
+++ b/react-app/src/pages/dashboard/dashboard.css
@@ -304,6 +304,11 @@
   background-color: #f5f5f5; /* Color of the scrollbar track */
 }
 
+.dashboard--question--table {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(0, 0, 0, 0.5) #f5f5f5;
+}
+
 .dashboard--question--table thead tr th {
   padding: 1rem;
 }
@@ -675,6 +680,12 @@ input[type="file"][value]:not([value=""]) {
   width: 100%;
   max-width: 350px;
   margin: 10px;
+}
+
+@media (max-width: 1024px) {
+  .no-tablet {
+    display: none;
+  }
 }
 
 @media (max-width: 768px) {

--- a/react-app/src/pages/dashboard/dashboard.css
+++ b/react-app/src/pages/dashboard/dashboard.css
@@ -727,9 +727,20 @@ input[type="file"][value]:not([value=""]) {
     width: 30vw;
   }
 
+  .dashboard--next--page {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
   .dashboard--next--page span {
     width: 30vw;
     padding: 1rem;
+  }
+
+  .dashboard--button--next {
+    width: auto;
+    min-width: 5rem;
+    padding: 0.5rem 1rem;
   }
 
   .dashboard--button {

--- a/react-app/src/styles/global.css
+++ b/react-app/src/styles/global.css
@@ -226,7 +226,4 @@ div.alert.alert--linkable.alert--info:hover {
     margin: 8px;
     width: 97%;
   }
-  .dashboard--overview {
-    display: none !important;
-  }
 }

--- a/react-app/webpack.config.js
+++ b/react-app/webpack.config.js
@@ -35,6 +35,13 @@ module.exports = {
         type: "asset/source",
       },
       {
+        test: /\.woff2$/,
+        type: "asset/resource",
+        generator: {
+          filename: "./fonts/[name]-[hash][ext]",
+        },
+      },
+      {
         test: /\.(jpe?g|png|gif|svg|webp)$/i,
         type: "asset/resource",
         generator: {


### PR DESCRIPTION
Closes #83.

## Summary

- Remove duplicate `viewport` meta tag that disabled pinch-to-zoom (WCAG 1.4.4 fix)
- Self-host Material Symbols Outlined font via `material-symbols` npm package — eliminates FOUC from Google Fonts CDN load
- Stack dashboard sidebar above table on mobile (≤768px) instead of hiding it entirely
- Make pie chart containers fluid (`width: 100%`, `max-width: 300px`) so they render on narrow screens
- Scale down action buttons on mobile (`height: auto`, smaller font/padding)
- Fix modal overflow: Add Participants uses `min(500px, 90vw)` + `max-height: 90vh`; Create Survey reduces horizontal padding on mobile
- Add `≤1024px` tablet breakpoint hiding Statement/Results columns while keeping Type/Links visible
- Add Firefox `scrollbar-width`/`scrollbar-color` parity with existing webkit scrollbar rules
- Fix pagination controls overflowing on mobile (`width: auto`, `flex-wrap`)
- Fix unequal button heights in the Create/Add Participants pair
- Stack Surveys heading and filter to column on mobile so they don't fight for space
- Left-align pagination on desktop to match the table header

🤖 Generated with [Claude Code](https://claude.com/claude-code)