### PR TITLE
Survey Builder Phase 1: DB-backed SurveyTemplate model and API

### DIFF
--- a/docs/ROUTES.md
+++ b/docs/ROUTES.md
@@ -15,11 +15,12 @@ The icon ⚠️ indicates that the routes in the given group require login to re
 * [Participants](#participants)
   * [Data Entry](#data-entry)
   * [Data Queries](#data-queries)
+* [Survey Templates](#survey-templates)
 * [Surveys](#surveys)
   * [List Surveys](#list-surveys)
   * [Create Survey](#create-survey)
   * [Close Surveys](#close-surveys)
-* [Voting](#voting) 
+* [Voting](#voting)
 * [Links](#links)
 * [Results](#results)
 * [Pages](#pages)
@@ -167,6 +168,81 @@ discipline=2
 
 
 ---
+# Survey Templates
+Session-authorization protected route. ⚠️
+
+Survey templates define the structure of a survey: an ordered list of question slots, each with a type (`likert` or `checkbox`) and placeholder text. The four built-in templates (`LI`, `L2E`, `L3C`, `LI3`) cannot be modified or deleted. Custom templates can be created, updated, and deleted provided no surveys have been created from them.
+
+Templates are looked up by their `slug` in all detail, update, and delete routes.
+
+## List Templates
+`GET /api/survey/templates/`
+
+Returns all templates (not paginated).
+
+```json
+[
+  {
+    "id": 1,
+    "label": "Single Likert",
+    "slug": "LI",
+    "slots": [
+      { "id": "q0", "type": "likert", "placeholder": "Enter the statement participants will see" }
+    ],
+    "is_builtin": true,
+    "survey_count": 14,
+    "created_at": "2026-04-13T19:18:23.628Z",
+    "updated_at": "2026-04-13T19:18:23.628Z"
+  }
+]
+```
+
+## Retrieve Template
+`GET /api/survey/templates/<slug>/`
+
+Returns a single template by slug.
+
+## Create Template
+`POST /api/survey/templates/`
+
+```json
+{
+  "label": "My Custom Template",
+  "slug": "MYCUSTOM",
+  "slots": [
+    { "id": "q0", "type": "likert", "placeholder": "Statement 1" },
+    { "id": "q1", "type": "checkbox", "placeholder": "I have relevant expertise" }
+  ]
+}
+```
+
+Validation rules:
+- `slots` must be a non-empty list
+- Each slot must have an `id` (string) and a `type` of `likert` or `checkbox`
+- Slot `id` values must be unique within a template
+- `slug` must be unique across all templates
+
+Returns `201 Created` on success with the full template object.
+
+## Update Template
+`PATCH /api/survey/templates/<slug>/`
+
+Allows updating `label`, `slots`, or both. `slug` and `is_builtin` are read-only and any supplied values are ignored.
+
+Built-in templates (`is_builtin: true`) cannot be updated at all — returns `400 Bad Request`.
+
+If surveys have been created using this template, structural changes to slots (adding, removing, reordering, or changing the type of a slot) are blocked — returns `400 Bad Request`. Only `label` and slot `placeholder` text may be changed.
+
+## Delete Template
+`DELETE /api/survey/templates/<slug>/`
+
+Deletes a custom template. Returns `204 No Content` on success.
+
+Returns `400 Bad Request` if:
+- The template is built-in (`is_builtin: true`)
+- Any surveys have been created using this template
+
+---
 # Surveys
 Session-authorization protected route. ⚠️
 
@@ -178,13 +254,16 @@ Takes the optional `GET` parameter `?active=True`.
 
 Returns a filtered list of active surveys, accessible under the key `results`, values are data.
 
-```javascript
+```json
 {
   "results": [
     {
       "id": 1,
       "question": "Science has proven beyond all reasonable doubt that...",
       "kind": "LI",
+      "template_slots": [
+        { "id": "q0", "type": "likert", "placeholder": "Enter the statement participants will see" }
+      ],
       "active": "True",
       "expiry": "2023-05-01T12:34:56.789Z",
       "participants": 10000,

--- a/iasc/admin.py
+++ b/iasc/admin.py
@@ -2,13 +2,14 @@ from builtins import issubclass
 
 from django.contrib import admin
 from iasc.models import (
+    ActiveLink,
+    Discipline,
     Institution,
+    Participant,
+    Result,
     Survey,
     SurveyTemplate,
-    Result,
-    Participant,
-    Discipline,
-    ActiveLink,
+    SurveyTemplateSlot,
 )
 
 
@@ -42,7 +43,15 @@ class ActiveLinkAdmin(admin.ModelAdmin):
     list_display = ("unique_link", "participant", "survey")
 
 
+class SurveyTemplateSlotInline(admin.TabularInline):
+    model = SurveyTemplateSlot
+    extra = 0
+    fields = ("order", "slot_id", "type", "placeholder")
+    ordering = ("order",)
+
+
 @admin.register(SurveyTemplate)
 class SurveyTemplateAdmin(admin.ModelAdmin):
     list_display = ("slug", "label", "is_builtin", "created_at")
     readonly_fields = ("is_builtin", "created_at", "updated_at")
+    inlines = [SurveyTemplateSlotInline]

--- a/iasc/fixtures/survey_templates.json
+++ b/iasc/fixtures/survey_templates.json
@@ -5,13 +5,6 @@
   "fields": {
     "label": "Single Likert",
     "slug": "LI",
-    "slots": [
-      {
-        "id": "q0",
-        "type": "likert",
-        "placeholder": "Enter the statement participants will see"
-      }
-    ],
     "is_builtin": true,
     "created_at": "2026-04-13T19:18:23.628Z",
     "updated_at": "2026-04-13T19:18:23.628Z"
@@ -23,23 +16,6 @@
   "fields": {
     "label": "2 Likert + Checkbox",
     "slug": "L2E",
-    "slots": [
-      {
-        "id": "q0",
-        "type": "likert",
-        "placeholder": "Enter statement 1"
-      },
-      {
-        "id": "q1",
-        "type": "likert",
-        "placeholder": "Enter statement 2"
-      },
-      {
-        "id": "q2",
-        "type": "checkbox",
-        "placeholder": "Enter checkbox statement (e.g. I have relevant expertise)"
-      }
-    ],
     "is_builtin": true,
     "created_at": "2026-04-13T19:18:23.629Z",
     "updated_at": "2026-04-13T19:18:23.629Z"
@@ -51,28 +27,6 @@
   "fields": {
     "label": "3 Likert + Checkbox",
     "slug": "L3C",
-    "slots": [
-      {
-        "id": "q0",
-        "type": "likert",
-        "placeholder": "Enter statement 1"
-      },
-      {
-        "id": "q1",
-        "type": "likert",
-        "placeholder": "Enter statement 2"
-      },
-      {
-        "id": "q2",
-        "type": "likert",
-        "placeholder": "Enter statement 3"
-      },
-      {
-        "id": "q3",
-        "type": "checkbox",
-        "placeholder": "Enter checkbox statement (e.g. I have relevant expertise)"
-      }
-    ],
     "is_builtin": true,
     "created_at": "2026-04-13T19:18:23.631Z",
     "updated_at": "2026-04-13T19:18:23.631Z"
@@ -84,26 +38,130 @@
   "fields": {
     "label": "3 Likert",
     "slug": "LI3",
-    "slots": [
-      {
-        "id": "q0",
-        "type": "likert",
-        "placeholder": "Enter statement 1"
-      },
-      {
-        "id": "q1",
-        "type": "likert",
-        "placeholder": "Enter statement 2"
-      },
-      {
-        "id": "q2",
-        "type": "likert",
-        "placeholder": "Enter statement 3"
-      }
-    ],
     "is_builtin": true,
     "created_at": "2026-04-13T19:18:23.633Z",
     "updated_at": "2026-04-13T19:18:23.633Z"
+  }
+},
+{
+  "model": "iasc.surveytemplateslot",
+  "pk": 1,
+  "fields": {
+    "template": 1,
+    "order": 0,
+    "slot_id": "q0",
+    "type": "likert",
+    "placeholder": "Enter the statement participants will see"
+  }
+},
+{
+  "model": "iasc.surveytemplateslot",
+  "pk": 2,
+  "fields": {
+    "template": 2,
+    "order": 0,
+    "slot_id": "q0",
+    "type": "likert",
+    "placeholder": "Enter statement 1"
+  }
+},
+{
+  "model": "iasc.surveytemplateslot",
+  "pk": 3,
+  "fields": {
+    "template": 2,
+    "order": 1,
+    "slot_id": "q1",
+    "type": "likert",
+    "placeholder": "Enter statement 2"
+  }
+},
+{
+  "model": "iasc.surveytemplateslot",
+  "pk": 4,
+  "fields": {
+    "template": 2,
+    "order": 2,
+    "slot_id": "q2",
+    "type": "checkbox",
+    "placeholder": "Enter checkbox statement (e.g. I have relevant expertise)"
+  }
+},
+{
+  "model": "iasc.surveytemplateslot",
+  "pk": 5,
+  "fields": {
+    "template": 3,
+    "order": 0,
+    "slot_id": "q0",
+    "type": "likert",
+    "placeholder": "Enter statement 1"
+  }
+},
+{
+  "model": "iasc.surveytemplateslot",
+  "pk": 6,
+  "fields": {
+    "template": 3,
+    "order": 1,
+    "slot_id": "q1",
+    "type": "likert",
+    "placeholder": "Enter statement 2"
+  }
+},
+{
+  "model": "iasc.surveytemplateslot",
+  "pk": 7,
+  "fields": {
+    "template": 3,
+    "order": 2,
+    "slot_id": "q2",
+    "type": "likert",
+    "placeholder": "Enter statement 3"
+  }
+},
+{
+  "model": "iasc.surveytemplateslot",
+  "pk": 8,
+  "fields": {
+    "template": 3,
+    "order": 3,
+    "slot_id": "q3",
+    "type": "checkbox",
+    "placeholder": "Enter checkbox statement (e.g. I have relevant expertise)"
+  }
+},
+{
+  "model": "iasc.surveytemplateslot",
+  "pk": 9,
+  "fields": {
+    "template": 4,
+    "order": 0,
+    "slot_id": "q0",
+    "type": "likert",
+    "placeholder": "Enter statement 1"
+  }
+},
+{
+  "model": "iasc.surveytemplateslot",
+  "pk": 10,
+  "fields": {
+    "template": 4,
+    "order": 1,
+    "slot_id": "q1",
+    "type": "likert",
+    "placeholder": "Enter statement 2"
+  }
+},
+{
+  "model": "iasc.surveytemplateslot",
+  "pk": 11,
+  "fields": {
+    "template": 4,
+    "order": 2,
+    "slot_id": "q2",
+    "type": "likert",
+    "placeholder": "Enter statement 3"
   }
 }
 ]

--- a/iasc/migrations/0011_seed_builtin_survey_templates.py
+++ b/iasc/migrations/0011_seed_builtin_survey_templates.py
@@ -1,8 +1,7 @@
 """
 Data migration: seed the four builtin SurveyTemplate rows from
-conf/survey_definitions.json.  Slugs are lowercased kind codes so that
-existing Survey.kind values (e.g. "LI", "L2E") continue to validate —
-validate_survey_kind() now does a case-insensitive lookup.
+conf/survey_definitions.json.  Slug values match existing Survey.kind values
+(e.g. "LI", "L2E") so that validate_survey_kind() continues to accept them.
 """
 
 import json

--- a/iasc/migrations/0012_normalise_slots_to_surveytemplateslot.py
+++ b/iasc/migrations/0012_normalise_slots_to_surveytemplateslot.py
@@ -1,0 +1,63 @@
+# Create the SurveyTemplateSlot table.  Data is migrated from
+# SurveyTemplate.slots in 0013; the slots JSONField is removed in 0014.
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("iasc", "0011_seed_builtin_survey_templates"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="SurveyTemplateSlot",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("order", models.PositiveIntegerField()),
+                (
+                    "slot_id",
+                    models.CharField(help_text='Vote key, e.g. "q0"', max_length=32),
+                ),
+                (
+                    "type",
+                    models.CharField(
+                        choices=[("likert", "Likert"), ("checkbox", "Checkbox")],
+                        max_length=32,
+                    ),
+                ),
+                ("placeholder", models.TextField(blank=True, default="")),
+                (
+                    "template",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="slot_set",
+                        to="iasc.surveytemplate",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["order"],
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=("template", "slot_id"),
+                        name="unique_slot_id_per_template",
+                    ),
+                    models.UniqueConstraint(
+                        fields=("template", "order"),
+                        name="unique_slot_order_per_template",
+                    ),
+                ],
+            },
+        ),
+    ]

--- a/iasc/migrations/0013_migrate_slots_json_to_surveytemplateslot.py
+++ b/iasc/migrations/0013_migrate_slots_json_to_surveytemplateslot.py
@@ -1,0 +1,49 @@
+# Data migration: move slot data from SurveyTemplate.slots (JSONField)
+# into the new SurveyTemplateSlot rows.
+
+from django.db import migrations
+
+
+def migrate_slots_forward(apps, schema_editor):
+    SurveyTemplate = apps.get_model("iasc", "SurveyTemplate")
+    SurveyTemplateSlot = apps.get_model("iasc", "SurveyTemplateSlot")
+    for template in SurveyTemplate.objects.all():
+        for order, slot in enumerate(template.slots or []):
+            SurveyTemplateSlot.objects.create(
+                template=template,
+                order=order,
+                slot_id=slot["id"],
+                type=slot["type"],
+                placeholder=slot.get("placeholder", ""),
+            )
+
+
+def migrate_slots_backward(apps, schema_editor):
+    SurveyTemplateSlot = apps.get_model("iasc", "SurveyTemplateSlot")
+    SurveyTemplate = apps.get_model("iasc", "SurveyTemplate")
+    for template in SurveyTemplate.objects.all():
+        slots = [
+            {
+                "id": s.slot_id,
+                "type": s.type,
+                "placeholder": s.placeholder,
+            }
+            for s in SurveyTemplateSlot.objects.filter(template=template).order_by(
+                "order"
+            )
+        ]
+        template.slots = slots
+        template.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("iasc", "0012_normalise_slots_to_surveytemplateslot"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            migrate_slots_forward, reverse_code=migrate_slots_backward
+        ),
+    ]

--- a/iasc/migrations/0014_remove_surveytemplate_slots_jsonfield.py
+++ b/iasc/migrations/0014_remove_surveytemplate_slots_jsonfield.py
@@ -1,0 +1,18 @@
+# Remove the now-redundant SurveyTemplate.slots JSONField.
+# Data has already been moved to SurveyTemplateSlot in migration 0013.
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("iasc", "0013_migrate_slots_json_to_surveytemplateslot"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="surveytemplate",
+            name="slots",
+        ),
+    ]

--- a/iasc/models.py
+++ b/iasc/models.py
@@ -16,24 +16,59 @@ def validate_survey_kind(value):
         raise ValidationError(f"Invalid survey kind '{value}'. Valid kinds: {valid}")
 
 
+SLOT_TYPE_LIKERT = "likert"
+SLOT_TYPE_CHECKBOX = "checkbox"
+SLOT_TYPE_CHOICES = [
+    (SLOT_TYPE_LIKERT, "Likert"),
+    (SLOT_TYPE_CHECKBOX, "Checkbox"),
+]
+
+
 class SurveyTemplate(models.Model):
     """
     Database-backed survey template, replacing conf/survey_definitions.json.
     Each template defines a reusable structure (ordered list of question slots)
-    that surveys are created from.
+    that surveys are created from.  Slots are stored in SurveyTemplateSlot.
     """
 
     label = models.CharField(max_length=255)
     slug = models.SlugField(max_length=32, unique=True, db_index=True)
-    slots = models.JSONField(
-        help_text="Ordered list of question slots: [{id, type, placeholder}]"
-    )
     is_builtin = models.BooleanField(default=False)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
     def __str__(self):
         return f"{self.label} ({self.slug})"
+
+
+class SurveyTemplateSlot(models.Model):
+    """
+    A single question slot within a SurveyTemplate.
+    Slots are ordered by their `order` field and identified by `slot_id`
+    (e.g. "q0", "q1") which becomes the key in the vote payload.
+    """
+
+    template = models.ForeignKey(
+        "SurveyTemplate", on_delete=models.CASCADE, related_name="slot_set"
+    )
+    order = models.PositiveIntegerField()
+    slot_id = models.CharField(max_length=32, help_text='Vote key, e.g. "q0"')
+    type = models.CharField(max_length=32, choices=SLOT_TYPE_CHOICES)
+    placeholder = models.TextField(blank=True, default="")
+
+    class Meta:
+        ordering = ["order"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["template", "slot_id"], name="unique_slot_id_per_template"
+            ),
+            models.UniqueConstraint(
+                fields=["template", "order"], name="unique_slot_order_per_template"
+            ),
+        ]
+
+    def __str__(self):
+        return f"{self.template.slug}[{self.order}] {self.slot_id} ({self.type})"
 
 
 class Institution(models.Model):

--- a/iasc/serializers.py
+++ b/iasc/serializers.py
@@ -5,8 +5,6 @@ from rest_framework import serializers
 
 from iasc import models
 
-VALID_SLOT_TYPES = {"likert", "checkbox"}
-
 UserModel = get_user_model()
 
 
@@ -69,28 +67,45 @@ class InstitutionSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
+class SurveyTemplateSlotSerializer(serializers.ModelSerializer):
+    """Serializes a SurveyTemplateSlot as {id, type, placeholder}."""
+
+    id = serializers.CharField(source="slot_id")
+
+    class Meta:
+        model = models.SurveyTemplateSlot
+        fields = ["id", "type", "placeholder"]
+
+
+def _template_slots_list(kind):
+    """Return [{id, type, placeholder}] for the given kind slug, or None."""
+    slots = models.SurveyTemplateSlot.objects.filter(template__slug=kind).order_by(
+        "order"
+    )
+    if not slots.exists():
+        return None
+    return SurveyTemplateSlotSerializer(slots, many=True).data
+
+
 class SurveyTemplateSerializer(serializers.ModelSerializer):
+    slots = SurveyTemplateSlotSerializer(source="slot_set", many=True)
     survey_count = serializers.SerializerMethodField()
 
     def get_survey_count(self, obj):
         return models.Survey.objects.filter(kind=obj.slug).count()
 
     def validate_slots(self, value):
-        if not isinstance(value, list) or len(value) == 0:
+        # value is a list of validated slot dicts with model field names (slot_id, type, placeholder)
+        if not value:
             raise serializers.ValidationError("slots must be a non-empty list.")
+        valid_types = {c[0] for c in models.SLOT_TYPE_CHOICES}
         for i, slot in enumerate(value):
-            if not isinstance(slot, dict):
-                raise serializers.ValidationError(f"Slot {i} must be an object.")
-            if "id" not in slot or "type" not in slot:
+            if slot.get("type", "") not in valid_types:
                 raise serializers.ValidationError(
-                    f"Slot {i} must have 'id' and 'type' fields."
+                    f"Slot {i} type '{slot.get('type', '')}' is not valid. "
+                    f"Valid types: {sorted(valid_types)}"
                 )
-            if slot["type"] not in VALID_SLOT_TYPES:
-                raise serializers.ValidationError(
-                    f"Slot {i} type '{slot['type']}' is not valid. "
-                    f"Valid types: {sorted(VALID_SLOT_TYPES)}"
-                )
-        ids = [s["id"] for s in value]
+        ids = [s["slot_id"] for s in value]
         if len(ids) != len(set(ids)):
             raise serializers.ValidationError(
                 "Slot ids must be unique within a template."
@@ -98,21 +113,51 @@ class SurveyTemplateSerializer(serializers.ModelSerializer):
         return value
 
     def validate(self, data):
-        # Block structural edits on templates that already have surveys
-        if self.instance is not None:
-            existing_slots = self.instance.slots
-            new_slots = data.get("slots", existing_slots)
-            if new_slots != existing_slots:
-                survey_count = models.Survey.objects.filter(
-                    kind=self.instance.slug
-                ).count()
-                if survey_count > 0:
+        # Block structural edits (slot IDs or types) when surveys already exist.
+        if self.instance is not None and "slot_set" in data:
+            existing = list(
+                models.SurveyTemplateSlot.objects.filter(template=self.instance)
+                .order_by("order")
+                .values_list("slot_id", "type")
+            )
+            incoming = [(s["slot_id"], s["type"]) for s in data["slot_set"]]
+            if incoming != existing:
+                if models.Survey.objects.filter(kind=self.instance.slug).exists():
                     raise serializers.ValidationError(
                         "Cannot change slot structure: surveys already exist using "
                         "this template. You may only update the label or slot "
                         "placeholder text."
                     )
         return data
+
+    def create(self, validated_data):
+        slot_data = validated_data.pop("slot_set", [])
+        template = models.SurveyTemplate.objects.create(**validated_data)
+        for order, slot in enumerate(slot_data):
+            models.SurveyTemplateSlot.objects.create(
+                template=template,
+                order=order,
+                slot_id=slot["slot_id"],
+                type=slot["type"],
+                placeholder=slot.get("placeholder", ""),
+            )
+        return template
+
+    def update(self, instance, validated_data):
+        slot_data = validated_data.pop("slot_set", None)
+        instance.label = validated_data.get("label", instance.label)
+        instance.save()
+        if slot_data is not None:
+            models.SurveyTemplateSlot.objects.filter(template=instance).delete()
+            for order, slot in enumerate(slot_data):
+                models.SurveyTemplateSlot.objects.create(
+                    template=instance,
+                    order=order,
+                    slot_id=slot["slot_id"],
+                    type=slot["type"],
+                    placeholder=slot.get("placeholder", ""),
+                )
+        return instance
 
     class Meta:
         model = models.SurveyTemplate
@@ -133,11 +178,7 @@ class SurveySerializer(serializers.ModelSerializer):
     template_slots = serializers.SerializerMethodField()
 
     def get_template_slots(self, obj):
-        try:
-            template = models.SurveyTemplate.objects.get(slug=obj.kind)
-            return template.slots
-        except models.SurveyTemplate.DoesNotExist:
-            return None
+        return _template_slots_list(obj.kind)
 
     class Meta:
         model = models.Survey
@@ -179,11 +220,7 @@ class SurveyResultSerializer(serializers.ModelSerializer):
     template_slots = serializers.SerializerMethodField()
 
     def get_template_slots(self, obj):
-        try:
-            template = models.SurveyTemplate.objects.get(slug=obj.survey.kind)
-            return template.slots
-        except models.SurveyTemplate.DoesNotExist:
-            return None
+        return _template_slots_list(obj.survey.kind)
 
     def get_count(self, obj):
         return models.Result.objects.filter(survey_id=obj.survey.id).count()

--- a/iasc/serializers.py
+++ b/iasc/serializers.py
@@ -79,17 +79,21 @@ class SurveyTemplateSlotSerializer(serializers.ModelSerializer):
 
 def _template_slots_list(kind):
     """Return [{id, type, placeholder}] for the given kind slug, or None."""
-    slots = models.SurveyTemplateSlot.objects.filter(template__slug=kind).order_by(
-        "order"
+    slots = list(
+        models.SurveyTemplateSlot.objects.filter(template__slug=kind).order_by("order")
     )
-    if not slots.exists():
-        return None
-    return SurveyTemplateSlotSerializer(slots, many=True).data
+    return SurveyTemplateSlotSerializer(slots, many=True).data or None
 
 
 class SurveyTemplateSerializer(serializers.ModelSerializer):
     slots = SurveyTemplateSlotSerializer(source="slot_set", many=True)
     survey_count = serializers.SerializerMethodField()
+
+    def get_fields(self):
+        fields = super().get_fields()
+        if self.instance is not None:
+            fields["slug"].read_only = True
+        return fields
 
     def get_survey_count(self, obj):
         return models.Survey.objects.filter(kind=obj.slug).count()

--- a/iasc/survey_defs.py
+++ b/iasc/survey_defs.py
@@ -18,8 +18,11 @@ def get_valid_slugs():
     (e.g. during initial migrate before the SurveyTemplate migration has run).
     """
     try:
+        from django.core.exceptions import AppRegistryNotReady
+        from django.db import DatabaseError
+
         from iasc.models import SurveyTemplate
 
         return list(SurveyTemplate.objects.values_list("slug", flat=True))
-    except Exception:
+    except (AppRegistryNotReady, DatabaseError):
         return VALID_KINDS

--- a/iasc/tests.py
+++ b/iasc/tests.py
@@ -1174,8 +1174,6 @@ class SurveyTemplateTestCase(TestCase):
 
     def test_survey_serializer_includes_template_slots(self):
         """GET /api/survey/<id>/ includes template_slots from the linked template."""
-        institution = Institution.objects.create(name="Slots Test Uni", country="GB")
-        discipline = Discipline.objects.create(name="SlotsDiscipline")
         survey = Survey.objects.create(
             question="Template slots test",
             active=True,
@@ -1286,6 +1284,46 @@ class SurveyTemplateTestCase(TestCase):
             {"slots": [{"id": "q0", "type": "checkbox", "placeholder": "Changed"}]},
             expected_status=400,
         )
+
+    def test_patch_slots_allowed_when_no_surveys_exist(self):
+        """Changing slot structure is allowed when no surveys use this template."""
+        data = self._patch(
+            f"/api/survey/templates/{self.custom.slug}/",
+            {
+                "slots": [
+                    {"id": "q0", "type": "likert", "placeholder": "New statement"},
+                    {"id": "q1", "type": "checkbox", "placeholder": "New checkbox"},
+                ]
+            },
+        )
+        self.assertEqual(len(data["slots"]), 2)
+        self.assertEqual(data["slots"][1]["type"], "checkbox")
+
+    def test_survey_results_serializer_includes_template_slots(self):
+        """GET /api/survey/results/ includes template_slots for each result survey."""
+        from iasc.models import Result
+
+        survey = Survey.objects.create(
+            question="Result slots test",
+            active=True,
+            kind="LI",
+            expiry=datetime.datetime(2099, 1, 1),
+        )
+        institution = Institution.objects.create(name="ResultSlotsUni", country="GB")
+        discipline = Discipline.objects.create(name="ResultSlotsDiscipline")
+        Result.objects.create(
+            survey=survey,
+            vote=3,
+            institution=institution,
+            discipline=discipline,
+        )
+        data = self._get("/api/survey/results/")
+        results = data.get("results", [])
+        matching = [r for r in results if r["id"] == survey.id]
+        self.assertEqual(len(matching), 1)
+        self.assertIn("template_slots", matching[0])
+        self.assertIsNotNone(matching[0]["template_slots"])
+        self.assertEqual(matching[0]["template_slots"][0]["type"], "likert")
 
     # --- delete ---
 

--- a/iasc/tests.py
+++ b/iasc/tests.py
@@ -1095,6 +1095,24 @@ class DatabaseModelTestCase(TestCase):
 class SurveyTemplateTestCase(TestCase):
     """Tests for SurveyTemplate model and /api/survey/templates/ endpoints."""
 
+    @staticmethod
+    def _make_template(label, slug, slots, is_builtin=False):
+        """Helper: create a SurveyTemplate with its SurveyTemplateSlot rows."""
+        from iasc.models import SurveyTemplate, SurveyTemplateSlot
+
+        tmpl = SurveyTemplate.objects.create(
+            label=label, slug=slug, is_builtin=is_builtin
+        )
+        for order, slot in enumerate(slots):
+            SurveyTemplateSlot.objects.create(
+                template=tmpl,
+                order=order,
+                slot_id=slot["id"],
+                type=slot["type"],
+                placeholder=slot.get("placeholder", ""),
+            )
+        return tmpl
+
     def setUp(self):
         super().setUp()
         from iasc.models import SurveyTemplate
@@ -1110,11 +1128,10 @@ class SurveyTemplateTestCase(TestCase):
         self.json_mt = "application/json"
 
         # Create a non-builtin template for mutation tests
-        self.custom = SurveyTemplate.objects.create(
-            label="Custom Template",
-            slug="CUSTOM",
-            slots=[{"id": "q0", "type": "likert", "placeholder": "Rate this"}],
-            is_builtin=False,
+        self.custom = self._make_template(
+            "Custom Template",
+            "CUSTOM",
+            [{"id": "q0", "type": "likert", "placeholder": "Rate this"}],
         )
 
     def _get(self, url, expected_status=200):
@@ -1264,10 +1281,8 @@ class SurveyTemplateTestCase(TestCase):
     # --- delete ---
 
     def test_delete_custom_template(self):
-        unused = self.SurveyTemplate.objects.create(
-            label="Unused",
-            slug="UNUSED1",
-            slots=[{"id": "q0", "type": "likert", "placeholder": "x"}],
+        unused = self._make_template(
+            "Unused", "UNUSED1", [{"id": "q0", "type": "likert", "placeholder": "x"}]
         )
         self._delete(f"/api/survey/templates/{unused.slug}/")
         self.assertFalse(self.SurveyTemplate.objects.filter(slug="UNUSED1").exists())

--- a/iasc/tests.py
+++ b/iasc/tests.py
@@ -1257,6 +1257,15 @@ class SurveyTemplateTestCase(TestCase):
         )
         self.assertEqual(data["label"], "Renamed")
 
+    def test_patch_slug_is_ignored(self):
+        """slug is read-only on update; sending a new value has no effect."""
+        data = self._patch(
+            f"/api/survey/templates/{self.custom.slug}/",
+            {"slug": "NEWSLUG"},
+        )
+        self.assertEqual(data["slug"], self.custom.slug)
+        self.assertFalse(self.SurveyTemplate.objects.filter(slug="NEWSLUG").exists())
+
     def test_patch_builtin_template_rejected(self):
         self._patch(
             "/api/survey/templates/LI/",

--- a/iasc/views.py
+++ b/iasc/views.py
@@ -562,7 +562,7 @@ class SurveyTemplateViewSet(viewsets.ModelViewSet):
 
     permission_classes = (permissions.IsAuthenticated,)
     serializer_class = serializers.SurveyTemplateSerializer
-    queryset = SurveyTemplate.objects.all().order_by("id")
+    queryset = SurveyTemplate.objects.prefetch_related("slot_set").order_by("id")
     pagination_class = None
     lookup_field = "slug"
 
@@ -594,10 +594,6 @@ class SurveyTemplateViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         return super().update(request, *args, **kwargs)
-
-    def partial_update(self, request, *args, **kwargs):
-        kwargs["partial"] = True
-        return self.update(request, *args, **kwargs)
 
 
 # Azure Healthcheck route

--- a/iasc/views.py
+++ b/iasc/views.py
@@ -413,7 +413,11 @@ class SurveyViewSet(viewsets.ReadOnlyModelViewSet):
 
 class SurveyResultsViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
-    queryset = Result.objects.filter(survey__isnull=False).distinct("survey_id")
+    queryset = (
+        Result.objects.filter(survey__isnull=False)
+        .select_related("survey")
+        .distinct("survey_id")
+    )
 
     pagination_class = None
     serializer_class = serializers.SurveyResultSerializer


### PR DESCRIPTION
Closes part of #53.

## Summary

- Adds `SurveyTemplate` and `SurveyTemplateSlot` models to replace `conf/survey_definitions.json` as the source of truth for survey structure
- Seeds the four existing builtin templates (`LI`, `L2E`, `L3C`, `LI3`) via data migration, preserving all existing surveys and vote data
- Exposes full CRUD at `GET/POST /api/survey/templates/` and `GET/PATCH/DELETE /api/survey/templates/<slug>/`; builtin templates and templates referenced by surveys are protected
- `SurveySerializer` and `SurveyResultSerializer` now include `template_slots` in their response so the public voting page can get slot definitions without an authenticated fetch
- `validate_survey_kind()` now queries the DB rather than a hardcoded list, so custom admin-created templates are accepted immediately
- 20 tests covering CRUD, validation rules, builtin/reference protection, and serializer integration

## Design note

The plan proposed a `slots` JSONField on `SurveyTemplate`. During implementation this was normalised into a proper `SurveyTemplateSlot` relational table — see issue comment for the relevant commits and rationale.