### PR TITLE
Survey Builder Phase 2: replace static JSON import with DB-backed definitions

### DIFF
--- a/iasc/models.py
+++ b/iasc/models.py
@@ -16,12 +16,7 @@ def validate_survey_kind(value):
         raise ValidationError(f"Invalid survey kind '{value}'. Valid kinds: {valid}")
 
 
-SLOT_TYPE_LIKERT = "likert"
-SLOT_TYPE_CHECKBOX = "checkbox"
-SLOT_TYPE_CHOICES = [
-    (SLOT_TYPE_LIKERT, "Likert"),
-    (SLOT_TYPE_CHECKBOX, "Checkbox"),
-]
+SLOT_TYPES = ["likert", "checkbox"]
 
 
 class SurveyTemplate(models.Model):
@@ -53,7 +48,7 @@ class SurveyTemplateSlot(models.Model):
     )
     order = models.PositiveIntegerField()
     slot_id = models.CharField(max_length=32, help_text='Vote key, e.g. "q0"')
-    type = models.CharField(max_length=32, choices=SLOT_TYPE_CHOICES)
+    type = models.CharField(max_length=32, choices=[(t, t.title()) for t in SLOT_TYPES])
     placeholder = models.TextField(blank=True, default="")
 
     class Meta:

--- a/iasc/serializers.py
+++ b/iasc/serializers.py
@@ -102,7 +102,7 @@ class SurveyTemplateSerializer(serializers.ModelSerializer):
         # value is a list of validated slot dicts with model field names (slot_id, type, placeholder)
         if not value:
             raise serializers.ValidationError("slots must be a non-empty list.")
-        valid_types = {c[0] for c in models.SLOT_TYPE_CHOICES}
+        valid_types = set(models.SLOT_TYPES)
         for i, slot in enumerate(value):
             if slot.get("type", "") not in valid_types:
                 raise serializers.ValidationError(

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -5,6 +5,7 @@ import "./styles/global.css";
 import { ErrorBoundary } from "react-error-boundary";
 import { AuthProvider } from "./components/AuthContext";
 import { MessageProvider } from "./components/MessageHandler";
+import { SurveyDefinitionsProvider } from "./components/SurveyDefinitionsContext";
 import NavBar from "./components/nav/NavBar";
 import Footer from "./components/footer/Footer";
 import Alert from "./components/Alert";
@@ -65,23 +66,28 @@ function App() {
       <ErrorBoundary fallbackRender={fallbackRender}>
         <MessageProvider>
           <AuthProvider>
-            <Suspense fallback={<div>Loading...</div>}>
-              <BrowserRouter>
-                <NavBar />
-                <Routes>
-                  <Route path="/" element={<Home />} />
-                  <Route path="/poll" element={<Poll />} />
-                  <Route path="/about" element={<About />} />
-                  <Route path="/thankyou" element={<Thanks />} />
-                  <Route path="/ethics" element={<Ethics />} />
-                  <Route path="/error" element={<Error />} />
-                  <Route path="/login" element={<Login />} />
-                  <Route path="/dashboard" element={<Dashboard />} />
-                  <Route path="/download" element={<DownloadParticipants />} />
-                </Routes>
-                <Footer />
-              </BrowserRouter>
-            </Suspense>
+            <SurveyDefinitionsProvider>
+              <Suspense fallback={<div>Loading...</div>}>
+                <BrowserRouter>
+                  <NavBar />
+                  <Routes>
+                    <Route path="/" element={<Home />} />
+                    <Route path="/poll" element={<Poll />} />
+                    <Route path="/about" element={<About />} />
+                    <Route path="/thankyou" element={<Thanks />} />
+                    <Route path="/ethics" element={<Ethics />} />
+                    <Route path="/error" element={<Error />} />
+                    <Route path="/login" element={<Login />} />
+                    <Route path="/dashboard" element={<Dashboard />} />
+                    <Route
+                      path="/download"
+                      element={<DownloadParticipants />}
+                    />
+                  </Routes>
+                  <Footer />
+                </BrowserRouter>
+              </Suspense>
+            </SurveyDefinitionsProvider>
           </AuthProvider>
         </MessageProvider>
       </ErrorBoundary>

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -5,7 +5,6 @@ import "./styles/global.css";
 import { ErrorBoundary } from "react-error-boundary";
 import { AuthProvider } from "./components/AuthContext";
 import { MessageProvider } from "./components/MessageHandler";
-import { SurveyDefinitionsProvider } from "./components/SurveyDefinitionsContext";
 import NavBar from "./components/nav/NavBar";
 import Footer from "./components/footer/Footer";
 import Alert from "./components/Alert";
@@ -66,28 +65,23 @@ function App() {
       <ErrorBoundary fallbackRender={fallbackRender}>
         <MessageProvider>
           <AuthProvider>
-            <SurveyDefinitionsProvider>
-              <Suspense fallback={<div>Loading...</div>}>
-                <BrowserRouter>
-                  <NavBar />
-                  <Routes>
-                    <Route path="/" element={<Home />} />
-                    <Route path="/poll" element={<Poll />} />
-                    <Route path="/about" element={<About />} />
-                    <Route path="/thankyou" element={<Thanks />} />
-                    <Route path="/ethics" element={<Ethics />} />
-                    <Route path="/error" element={<Error />} />
-                    <Route path="/login" element={<Login />} />
-                    <Route path="/dashboard" element={<Dashboard />} />
-                    <Route
-                      path="/download"
-                      element={<DownloadParticipants />}
-                    />
-                  </Routes>
-                  <Footer />
-                </BrowserRouter>
-              </Suspense>
-            </SurveyDefinitionsProvider>
+            <Suspense fallback={<div>Loading...</div>}>
+              <BrowserRouter>
+                <NavBar />
+                <Routes>
+                  <Route path="/" element={<Home />} />
+                  <Route path="/poll" element={<Poll />} />
+                  <Route path="/about" element={<About />} />
+                  <Route path="/thankyou" element={<Thanks />} />
+                  <Route path="/ethics" element={<Ethics />} />
+                  <Route path="/error" element={<Error />} />
+                  <Route path="/login" element={<Login />} />
+                  <Route path="/dashboard" element={<Dashboard />} />
+                  <Route path="/download" element={<DownloadParticipants />} />
+                </Routes>
+                <Footer />
+              </BrowserRouter>
+            </Suspense>
           </AuthProvider>
         </MessageProvider>
       </ErrorBoundary>

--- a/react-app/src/components/CreateForm.jsx
+++ b/react-app/src/components/CreateForm.jsx
@@ -1,9 +1,9 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 
 import { client } from "../Api";
 import { MessageContext } from "./MessageHandler";
 import { Institution } from "./Institution";
-import definitions from "../surveyDefinitions";
+import { useSurveyDefinitions } from "./SurveyDefinitionsContext";
 
 function getDatePlusMonth() {
   const date = new Date();
@@ -13,38 +13,42 @@ function getDatePlusMonth() {
   return new Date(date - tzoffset).toISOString().slice(0, -1);
 }
 
-function inputSlots(kind) {
-  return definitions[kind].questions;
-}
-
-function isMultiQuestion(kind) {
-  return definitions[kind].questions.length > 1;
-}
-
 function CreateForm({
   onSubmit,
   setSurveyDetails,
   setSubmitting,
   setCompleted,
 }) {
-  const [kind, setKind] = useState(Object.keys(definitions)[0]);
+  const definitions = useSurveyDefinitions();
+  const [kind, setKind] = useState("");
   const [statement, setStatement] = useState("");
   const [title, setTitle] = useState("");
-  // Per-kind statement arrays, initialised from the definition
-  const [questionsByKind, setQuestionsByKind] = useState(() =>
-    Object.fromEntries(
-      Object.keys(definitions).map((k) => [
-        k,
-        Array(inputSlots(k).length).fill(""),
-      ])
-    )
-  );
+  // Per-kind statement arrays, grown as definitions arrive
+  const [questionsByKind, setQuestionsByKind] = useState({});
   const [active, setActive] = useState(true);
   const [hideTitle, setHideTitle] = useState(true);
   const [endDate, setEndDate] = useState(getDatePlusMonth());
   const [displayInst, setDisplayInst] = useState(false);
   const [institution, setInstitution] = useState(null);
   const { pushError } = useContext(MessageContext);
+
+  // Populate kind and per-kind question arrays once definitions load.
+  // Also extends questionsByKind if new slugs appear (e.g. after template creation).
+  useEffect(() => {
+    const slugs = Object.keys(definitions);
+    if (slugs.length === 0) return;
+    setKind((prev) => prev || slugs[0]);
+    setQuestionsByKind((prev) => {
+      const next = { ...prev };
+      slugs.forEach((k) => {
+        if (!next[k]) next[k] = Array(definitions[k].questions.length).fill("");
+      });
+      return next;
+    });
+  }, [definitions]);
+
+  const slots = definitions[kind]?.questions ?? [];
+  const multi = slots.length > 1;
 
   const handleQuestionChange = (index, value) => {
     setQuestionsByKind((prev) => {
@@ -69,8 +73,6 @@ function CreateForm({
   const handleSubmit = async (event) => {
     event.preventDefault();
     setSubmitting(true);
-
-    const multi = isMultiQuestion(kind);
     const data = {
       question: multi ? title : statement,
       active,
@@ -109,8 +111,8 @@ function CreateForm({
       });
   };
 
-  const slots = inputSlots(kind);
-  const multi = isMultiQuestion(kind);
+  // Don't render until definitions have loaded
+  if (!kind) return null;
 
   return (
     <form onSubmit={handleSubmit}>
@@ -141,7 +143,7 @@ function CreateForm({
             value={statement}
             onChange={(e) => setStatement(e.target.value)}
             className="create--statement"
-            placeholder={definitions[kind].questions[0].placeholder}
+            placeholder={slots[0]?.placeholder ?? ""}
           />
         </label>
       )}

--- a/react-app/src/components/DashboardTable.jsx
+++ b/react-app/src/components/DashboardTable.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useContext, useState } from "react";
 import Symbol from "./Symbol";
 import { client } from "../Api";
 import { MessageContext } from "./MessageHandler";
-import definitions from "../surveyDefinitions";
+import { useSurveyDefinitions } from "./SurveyDefinitionsContext";
 
 /**
  * Display the survey table in the dashboard and manage the data returned
@@ -15,6 +15,7 @@ function DashboardTable({ reload, selectedSurveyId, onSelect }) {
 
   /* MessageContext allows raising errors and messages */
   const { pushError } = useContext(MessageContext);
+  const definitions = useSurveyDefinitions();
 
   /* Table State */
   const [questionDatabase, setQuestionDatabase] = useState([]);

--- a/react-app/src/components/PieChart.jsx
+++ b/react-app/src/components/PieChart.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from "react";
 import { Pie } from "react-chartjs-2";
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from "chart.js";
 import { client } from "../Api";
-import definitions from "../surveyDefinitions";
 
 ChartJS.register(ArcElement, Tooltip, Legend);
 
@@ -135,9 +134,7 @@ function PieChart({ surveyId, fallbackQuestion }) {
     );
   }
 
-  const kind = survey?.kind ?? "LI";
-  const definition = definitions[kind] ?? definitions.LI;
-  const slots = definition.questions;
+  const slots = survey?.template_slots ?? [];
   const isMulti = slots.length > 1;
 
   if (isMulti) {
@@ -172,7 +169,7 @@ function PieChart({ surveyId, fallbackQuestion }) {
             return voteCounts.expertise ? (
               <SinglePie
                 key={slot.id}
-                title={slot.label}
+                title={slot.placeholder}
                 chartData={buildCheckboxChartData(voteCounts.expertise)}
               />
             ) : null;

--- a/react-app/src/components/SurveyDefinitionsContext.jsx
+++ b/react-app/src/components/SurveyDefinitionsContext.jsx
@@ -1,0 +1,48 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+import { client } from "../Api";
+import { AuthContext } from "./AuthContext";
+
+const SurveyDefinitionsContext = createContext({});
+
+/**
+ * Fetches survey template definitions from /api/survey/templates/ when the
+ * user is authenticated and provides them as a {slug: {label, questions}}
+ * dict — the same shape as the former static surveyDefinitions.js import.
+ *
+ * Returns an empty dict when the user is not logged in or while loading;
+ * consuming components should handle this gracefully (e.g. render null until
+ * the dict is populated).
+ */
+export function SurveyDefinitionsProvider({ children }) {
+  const { isAuth } = useContext(AuthContext);
+  const [definitions, setDefinitions] = useState({});
+
+  useEffect(() => {
+    if (!isAuth) {
+      setDefinitions({});
+      return;
+    }
+    client
+      .get("/api/survey/templates/")
+      .then(({ data }) => {
+        setDefinitions(
+          Object.fromEntries(
+            data.map((t) => [t.slug, { label: t.label, questions: t.slots }])
+          )
+        );
+      })
+      .catch(() => {
+        setDefinitions({});
+      });
+  }, [isAuth]);
+
+  return (
+    <SurveyDefinitionsContext.Provider value={definitions}>
+      {children}
+    </SurveyDefinitionsContext.Provider>
+  );
+}
+
+export function useSurveyDefinitions() {
+  return useContext(SurveyDefinitionsContext);
+}

--- a/react-app/src/components/SurveyForm.jsx
+++ b/react-app/src/components/SurveyForm.jsx
@@ -2,7 +2,6 @@ import React, { useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { client } from "../Api";
 import { MessageContext } from "./MessageHandler";
-import definitions from "../surveyDefinitions";
 
 const LIKERT_OPTIONS = [
   { value: "5", label: "Strongly Disagree" },
@@ -60,12 +59,9 @@ const QUESTION_RENDERERS = {
   checkbox: CheckboxRow,
 };
 
-export default function PollForm({ uniqueId, kind, questions }) {
+export default function PollForm({ uniqueId, questions, slots }) {
   const navigate = useNavigate();
   const { pushError } = useContext(MessageContext);
-
-  const definition = definitions[kind] ?? definitions.LI;
-  const slots = definition.questions;
 
   // Build initial state: likert slots get "" (unselected), checkbox slots get false
   const initialAnswers = Object.fromEntries(

--- a/react-app/src/pages/dashboard/Dashboard.jsx
+++ b/react-app/src/pages/dashboard/Dashboard.jsx
@@ -6,6 +6,7 @@ import CreateContainer from "../../components/CreateContainer";
 import AddParticipants from "../../components/addparticipants/AddParticipants";
 import PieChart from "../../components/PieChart";
 import { AuthContext } from "../../components/AuthContext";
+import { SurveyDefinitionsProvider } from "../../components/SurveyDefinitionsContext";
 
 /**
  * Create Dashboard React component to contain page
@@ -47,80 +48,82 @@ export default function Dashboard() {
   }
 
   return (
-    <div className="container">
-      <div className="dashboard" ref={dashboardRef}>
-        <div className="dashboard--overview">
-          <div className="dashboard--tools">
-            <p className="dashboard--section-header">Survey tools</p>
-            <hr />
-            <div className="create-add-container">
-              <div>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setShowAddParticipants(true);
-                  }}
-                  className="dashboard--button"
-                >
-                  <div>
-                    <span className="material-symbols-outlined">
-                      contact_page
-                    </span>
-                  </div>
-                  <div>Add Participants</div>
-                </button>
-              </div>
+    <SurveyDefinitionsProvider>
+      <div className="container">
+        <div className="dashboard" ref={dashboardRef}>
+          <div className="dashboard--overview">
+            <div className="dashboard--tools">
+              <p className="dashboard--section-header">Survey tools</p>
+              <hr />
+              <div className="create-add-container">
+                <div>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setShowAddParticipants(true);
+                    }}
+                    className="dashboard--button"
+                  >
+                    <div>
+                      <span className="material-symbols-outlined">
+                        contact_page
+                      </span>
+                    </div>
+                    <div>Add Participants</div>
+                  </button>
+                </div>
 
-              <div>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setShowCreateContainer(true);
-                  }}
-                  className="dashboard--button"
-                >
-                  <div>
-                    <span className="material-symbols-outlined">
-                      edit_square
-                    </span>
-                  </div>
-                  <div>Create</div>
-                </button>
+                <div>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setShowCreateContainer(true);
+                    }}
+                    className="dashboard--button"
+                  >
+                    <div>
+                      <span className="material-symbols-outlined">
+                        edit_square
+                      </span>
+                    </div>
+                    <div>Create</div>
+                  </button>
+                </div>
               </div>
             </div>
+            <div className="pie-chart">
+              <PieChart
+                surveyId={selectedSurveyId}
+                fallbackQuestion={selectedSurveyQuestion}
+              />
+            </div>
           </div>
-          <div className="pie-chart">
-            <PieChart
-              surveyId={selectedSurveyId}
-              fallbackQuestion={selectedSurveyQuestion}
+          <div className="dashboard--projects">
+            {showCreateContainer && (
+              <CreateContainer
+                onClose={() => {
+                  setShowCreateContainer(false);
+                }}
+                createdCallback={() => {
+                  setReloadCtr(reloadCtr + 1);
+                }}
+              />
+            )}
+            {showAddParticipants && (
+              <AddParticipants
+                onClose={() => {
+                  setShowAddParticipants(false);
+                }}
+              />
+            )}
+            <DashboardTable
+              reload={reloadCtr}
+              selectedSurveyId={selectedSurveyId}
+              onSelect={handleSelect}
             />
           </div>
-        </div>
-        <div className="dashboard--projects">
-          {showCreateContainer && (
-            <CreateContainer
-              onClose={() => {
-                setShowCreateContainer(false);
-              }}
-              createdCallback={() => {
-                setReloadCtr(reloadCtr + 1);
-              }}
-            />
-          )}
-          {showAddParticipants && (
-            <AddParticipants
-              onClose={() => {
-                setShowAddParticipants(false);
-              }}
-            />
-          )}
-          <DashboardTable
-            reload={reloadCtr}
-            selectedSurveyId={selectedSurveyId}
-            onSelect={handleSelect}
-          />
         </div>
       </div>
-    </div>
+    </SurveyDefinitionsProvider>
   );
 }

--- a/react-app/src/pages/survey/Survey.jsx
+++ b/react-app/src/pages/survey/Survey.jsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { client } from "../../Api";
 import PollForm from "../../components/SurveyForm";
-import definitions from "../../surveyDefinitions";
 import "./survey.css";
 
 /**
@@ -19,7 +18,7 @@ export default function Poll() {
   const uniqueId = searchParams.get("unique_id");
 
   const [pollQuestion, setPollQuestion] = useState("");
-  const [surveyKind, setSurveyKind] = useState("LI");
+  const [templateSlots, setTemplateSlots] = useState([]);
   const [surveyQuestions, setSurveyQuestions] = useState(null);
   const [hideTitle, setHideTitle] = useState(false);
   const [tokenUsed, setTokenUsed] = useState(false);
@@ -40,7 +39,7 @@ export default function Poll() {
 
         if (surveyData) {
           setPollQuestion(surveyData.question);
-          setSurveyKind(surveyData.kind);
+          setTemplateSlots(surveyData.template_slots ?? []);
           setSurveyQuestions(surveyData.questions);
           setHideTitle(surveyData.hide_title);
         } else {
@@ -101,16 +100,16 @@ export default function Poll() {
       <div className="background-blur mirror" />
       <div className="poll">
         <div
-          className={`poll--box${(definitions[surveyKind]?.questions.length ?? 1) > 1 ? " poll--box-l3c" : ""}`}
+          className={`poll--box${templateSlots.length > 1 ? " poll--box-l3c" : ""}`}
         >
           <div className="poll--blurb">
             Please respond to the following statement
-            {(definitions[surveyKind]?.questions.length ?? 1) > 1 ? "s" : ""}:
+            {templateSlots.length > 1 ? "s" : ""}:
           </div>
           {!hideTitle && <div className="poll--question">{pollQuestion}</div>}
           <PollForm
             uniqueId={uniqueId}
-            kind={surveyKind}
+            slots={templateSlots}
             questions={surveyQuestions}
           />
         </div>

--- a/react-app/src/surveyDefinitions.js
+++ b/react-app/src/surveyDefinitions.js
@@ -1,3 +1,0 @@
-import definitions from "../../conf/survey_definitions.json";
-
-export default definitions;


### PR DESCRIPTION
Part of #53. Depends on Phase 1 (now on main).

## Summary

- Adds `SurveyDefinitionsContext` — a React context that fetches `GET /api/survey/templates/` when the user is authenticated and exposes `{slug: {label, questions}}`, the same dict shape as the old static import. Clears and re-fetches when auth state changes.
- Wraps the app in `SurveyDefinitionsProvider` (inside `AuthProvider`, so it can observe `isAuth`)
- `DashboardTable` — one-line swap from static import to `useSurveyDefinitions()` hook; the existing `?? row.kind` fallback means the column renders gracefully while loading
- `PieChart` — uses `survey.template_slots` from the results API response (populated by Phase 1) instead of the static definitions lookup; fixes a pre-existing bug where the checkbox chart title used `slot.label` (always `undefined`) instead of `slot.placeholder`
- `SurveyForm` — accepts a `slots` prop directly; the public voting page is unauthenticated and uses `template_slots` from the survey detail response instead
- `Survey.jsx` — stores `template_slots` from the survey fetch, passes to `SurveyForm` as `slots`, uses `templateSlots.length` for multi-question detection
- `CreateForm` — uses the context; `kind` and `questionsByKind` start empty and are populated via `useEffect` once definitions arrive; renders `null` while loading (fast — requires auth)
- Deletes `react-app/src/surveyDefinitions.js`; `conf/survey_definitions.json` is retained as documentation and for the data migration