### PR TITLE
Results aggregation dashboard (#51)

### DIFF
--- a/docs/ROUTES.md
+++ b/docs/ROUTES.md
@@ -417,14 +417,63 @@ Session-authorization protected route. ⚠️
 
 Retrieve survey results incrementally and following the close of a survey.
 
+## Aggregate vote counts
+`GET /api/survey/<id>/aggregate/` ⚠️
+
+Returns aggregated vote counts for a single survey, with optional filtering:
+
+```
+institution=1   (optional) filter to one institution
+discipline=2    (optional) filter to one discipline
+```
+
+Response shape matches `/api/survey/results/` per-survey entry but for a single survey:
+
+```json
+{
+  "id": 14,
+  "question": "Science has proven beyond...",
+  "kind": "LI",
+  "active": false,
+  "hide_title": false,
+  "participants": 250,
+  "voted": 180,
+  "count": 180,
+  "vote_counts": { "1": 45, "2": 72, "3": 30, "4": 20, "5": 13 },
+  "template_slots": [{ "id": "q0", "type": "likert", "placeholder": "..." }]
+}
+```
+
+Returns `404 Not Found` if the survey does not exist.
+
+## Vote timeseries
+`GET /api/survey/<id>/timeseries/` ⚠️
+
+Returns a compact daily time-series of votes received, suitable for a burn-up chart:
+
+```json
+{
+  "participants": 250,
+  "expiry": "2024-06-30T23:59:59Z",
+  "series": [
+    { "date": "2024-03-01", "count": 8,  "cumulative": 8 },
+    { "date": "2024-03-02", "count": 15, "cumulative": 23 }
+  ]
+}
+```
+
+Returns `404 Not Found` if the survey does not exist.
+
 ## Download Results
 `GET /api/result/`
 
 Provide the following parameters for survey ID, and OPTIONAL pagination:
 ```javascript
 survey=12
-page=1  *optional
-size=10 *optional
+institution=1   *optional
+discipline=2    *optional
+page=1          *optional
+size=10         *optional
 ```
 
 ### Download results as Microsoft Excel XLS
@@ -453,3 +502,4 @@ The following routes return pages in the React web application:
 | /dashboard/survey       | Perform survey administration actions: create, list, close     |
 | /dashboard/participants | Administer participants: upload CSV or Excel spreadsheet       |
 | /dashboard/results      | Retrieve survey results, while survey running or after closure |
+| /dashboard/results/:id  | Full results view: bar charts, burn-up chart, institution breakdown |

--- a/frontend/urls.py
+++ b/frontend/urls.py
@@ -9,7 +9,7 @@ urlpatterns = [
     path("ethics", views.index),
     path("poll", views.index),
     path("dashboard", views.index),
-    path("dashboard/results/<int:survey_id>", views.index),
+    path("dashboard/results/<int:survey_id>", lambda req, **_: views.index(req)),
     path("download", views.index),
     path("create", views.index),
     path("thankyou", views.index),

--- a/frontend/urls.py
+++ b/frontend/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path("ethics", views.index),
     path("poll", views.index),
     path("dashboard", views.index),
+    path("dashboard/results/<int:survey_id>", views.index),
     path("download", views.index),
     path("create", views.index),
     path("thankyou", views.index),

--- a/iasc/filters.py
+++ b/iasc/filters.py
@@ -6,10 +6,11 @@ from iasc.models import Result, ActiveLink, Participant, Survey
 class ResultFilter(filters.FilterSet):
     institution = filters.NumberFilter(field_name="institution_id")
     survey = filters.NumberFilter(field_name="survey_id")
+    discipline = filters.NumberFilter(field_name="discipline_id")
 
     class Meta:
         model = Result
-        fields = ["institution", "survey"]
+        fields = ["institution", "survey", "discipline"]
 
 
 class InstitutionFilter(filters.FilterSet):

--- a/iasc/serializers.py
+++ b/iasc/serializers.py
@@ -231,20 +231,7 @@ class SurveyResultSerializer(serializers.ModelSerializer):
 
     def get_vote_counts(self, obj):
         results = models.Result.objects.filter(survey_id=obj.survey.id)
-        counts = {}
-        for result in results:
-            if isinstance(result.vote, dict):
-                # multi-question vote: {"0": 3, "1": 2, ..., "3": true}
-                for sub_key, sub_val in result.vote.items():
-                    if sub_key not in counts:
-                        counts[sub_key] = {}
-                    val_key = str(sub_val)
-                    counts[sub_key][val_key] = counts[sub_key].get(val_key, 0) + 1
-            else:
-                # LI: vote is a plain integer
-                key = str(result.vote)
-                counts[key] = counts.get(key, 0) + 1
-        return counts
+        return compute_vote_counts(results)
 
     class Meta:
         model = models.Result
@@ -259,6 +246,44 @@ class SurveyResultSerializer(serializers.ModelSerializer):
             "count",
             "vote_counts",
         ]
+
+
+class SurveyAggregateSerializer(serializers.Serializer):
+    """
+    Returns vote_counts aggregated over a filtered Result queryset,
+    plus survey metadata. Used by GET /api/survey/<id>/aggregate/.
+    """
+
+    id = serializers.IntegerField()
+    question = serializers.CharField()
+    questions = serializers.JSONField()
+    kind = serializers.CharField()
+    active = serializers.BooleanField()
+    hide_title = serializers.BooleanField()
+    participants = serializers.IntegerField()
+    voted = serializers.IntegerField()
+    template_slots = serializers.SerializerMethodField()
+    count = serializers.IntegerField()
+    vote_counts = serializers.DictField()
+
+    def get_template_slots(self, obj):
+        return _template_slots_list(obj["kind"])
+
+
+def compute_vote_counts(results):
+    """Compute vote_counts dict from a Result queryset."""
+    counts = {}
+    for result in results:
+        if isinstance(result.vote, dict):
+            for sub_key, sub_val in result.vote.items():
+                if sub_key not in counts:
+                    counts[sub_key] = {}
+                val_key = str(sub_val)
+                counts[sub_key][val_key] = counts[sub_key].get(val_key, 0) + 1
+        else:
+            key = str(result.vote)
+            counts[key] = counts.get(key, 0) + 1
+    return counts
 
 
 class ActiveLinkSerializer(serializers.ModelSerializer):

--- a/iasc/tests.py
+++ b/iasc/tests.py
@@ -975,6 +975,116 @@ class DatabaseModelTestCase(TestCase):
             ActiveLink.objects.filter(unique_link=link.unique_link).exists()
         )
 
+    def _authed_client(self):
+        """Return a logged-in test client."""
+        user = User.objects.create(username="aggtest")
+        user.set_password("password")
+        user.save()
+        self.client.login(username="aggtest", password="password")
+        return self.client
+
+    def test_aggregate_endpoint_basic(self):
+        """GET /api/survey/<id>/aggregate/ returns vote_counts for a survey."""
+        link = ActiveLink.objects.get()
+        link.vote(3)
+
+        client = self._authed_client()
+        resp = client.get(f"/api/survey/{self.survey.id}/aggregate/")
+        self.assertEqual(resp.status_code, 200)
+
+        import json as json_mod
+
+        data = json_mod.loads(resp.content)
+        self.assertEqual(data["id"], self.survey.id)
+        self.assertEqual(data["kind"], "LI")
+        self.assertEqual(data["count"], 1)
+        self.assertIn("3", data["vote_counts"])
+
+    def test_aggregate_endpoint_404(self):
+        """GET /api/survey/99999/aggregate/ returns 404 for a missing survey."""
+        client = self._authed_client()
+        resp = client.get("/api/survey/99999/aggregate/")
+        self.assertEqual(resp.status_code, 404)
+
+    def test_aggregate_endpoint_institution_filter(self):
+        """GET /api/survey/<id>/aggregate/?institution=<id> filters by institution."""
+        other_inst = Institution.objects.create(name="Other Inst", country="US")
+        other_disc = Discipline.objects.create(name="Other Disc")
+        other_participant = Participant.objects.create(
+            email="other@test.invalid",
+            name="Other",
+            institution=other_inst,
+            discipline=other_disc,
+        )
+        # Vote from original participant (self.institution)
+        link = ActiveLink.objects.get()
+        link.vote(4)
+        # Vote from other institution participant — create survey link manually
+        Result.objects.create(
+            survey=self.survey,
+            vote=2,
+            institution=other_inst,
+            discipline=other_disc,
+        )
+
+        client = self._authed_client()
+        resp = client.get(
+            f"/api/survey/{self.survey.id}/aggregate/?institution={self.institution.id}"
+        )
+        self.assertEqual(resp.status_code, 200)
+
+        import json as json_mod
+
+        data = json_mod.loads(resp.content)
+        # Only the vote from self.institution (vote=4) should appear
+        self.assertEqual(data["count"], 1)
+        self.assertIn("4", data["vote_counts"])
+        self.assertNotIn("2", data["vote_counts"])
+
+    def test_timeseries_endpoint_basic(self):
+        """GET /api/survey/<id>/timeseries/ returns series with cumulative counts."""
+        link = ActiveLink.objects.get()
+        link.vote(5)
+
+        client = self._authed_client()
+        resp = client.get(f"/api/survey/{self.survey.id}/timeseries/")
+        self.assertEqual(resp.status_code, 200)
+
+        import json as json_mod
+
+        data = json_mod.loads(resp.content)
+        self.assertEqual(data["participants"], self.survey.participants)
+        self.assertIn("series", data)
+        self.assertEqual(len(data["series"]), 1)
+        self.assertEqual(data["series"][0]["count"], 1)
+        self.assertEqual(data["series"][0]["cumulative"], 1)
+
+    def test_timeseries_endpoint_404(self):
+        """GET /api/survey/99999/timeseries/ returns 404 for a missing survey."""
+        client = self._authed_client()
+        resp = client.get("/api/survey/99999/timeseries/")
+        self.assertEqual(resp.status_code, 404)
+
+    def test_result_filter_discipline(self):
+        """GET /api/result/?discipline=<id> filters results by discipline."""
+        other_disc = Discipline.objects.create(name="FilterDisc")
+        # Vote the existing link (uses self.discipline)
+        link = ActiveLink.objects.get()
+        link.vote(2)
+
+        client = self._authed_client()
+        resp = client.get(f"/api/result/?discipline={self.discipline.id}")
+        self.assertEqual(resp.status_code, 200)
+        import json as json_mod
+
+        data = json_mod.loads(resp.content)
+        self.assertEqual(data["count"], 1)
+
+        # Filter by a discipline with no results
+        resp2 = client.get(f"/api/result/?discipline={other_disc.id}")
+        data2 = json_mod.loads(resp2.content)
+        self.assertEqual(data2["count"], 0)
+
     def test_vote_validation_rejects_wrong_checkbox_type(self):
         """POST /api/vote/ with an integer where a boolean is expected returns 400."""
         link = self._l2e_link()

--- a/iasc/tests.py
+++ b/iasc/tests.py
@@ -1041,6 +1041,39 @@ class DatabaseModelTestCase(TestCase):
         self.assertIn("4", data["vote_counts"])
         self.assertNotIn("2", data["vote_counts"])
 
+    def test_aggregate_endpoint_multi_institution_filter(self):
+        """GET /api/survey/<id>/aggregate/?institution=1;2 filters by multiple institutions."""
+        inst_a = Institution.objects.create(name="Inst A", country="GB")
+        inst_b = Institution.objects.create(name="Inst B", country="DE")
+        inst_c = Institution.objects.create(name="Inst C", country="FR")
+        disc = Discipline.objects.create(name="Multi Disc")
+        # Consume the default active link (vote=1)
+        link = ActiveLink.objects.get()
+        link.vote(1)
+        # Votes from inst_a and inst_b should be included; inst_c excluded
+        Result.objects.create(
+            survey=self.survey, vote=2, institution=inst_a, discipline=disc
+        )
+        Result.objects.create(
+            survey=self.survey, vote=3, institution=inst_b, discipline=disc
+        )
+        Result.objects.create(
+            survey=self.survey, vote=5, institution=inst_c, discipline=disc
+        )
+
+        import json as json_mod
+
+        client = self._authed_client()
+        resp = client.get(
+            f"/api/survey/{self.survey.id}/aggregate/?institution={inst_a.id};{inst_b.id}"
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = json_mod.loads(resp.content)
+        self.assertEqual(data["count"], 2)
+        self.assertIn("2", data["vote_counts"])
+        self.assertIn("3", data["vote_counts"])
+        self.assertNotIn("5", data["vote_counts"])
+
     def test_timeseries_endpoint_basic(self):
         """GET /api/survey/<id>/timeseries/ returns series with cumulative counts."""
         link = ActiveLink.objects.get()

--- a/iasc/urls.py
+++ b/iasc/urls.py
@@ -55,6 +55,11 @@ urlpatterns = [
     path("login", views.UserLoginView.as_view(), name="login"),
     path("logout", views.UserLogoutView.as_view(), name="logout"),
     path("api/", include(router.urls)),
+    path(
+        "api/survey/<int:survey_id>/aggregate/",
+        views.SurveyAggregateView.as_view(),
+        name="survey-aggregate",
+    ),
     path("admin/", admin.site.urls),
 ]
 

--- a/iasc/urls.py
+++ b/iasc/urls.py
@@ -60,6 +60,11 @@ urlpatterns = [
         views.SurveyAggregateView.as_view(),
         name="survey-aggregate",
     ),
+    path(
+        "api/survey/<int:survey_id>/timeseries/",
+        views.SurveyTimeseriesView.as_view(),
+        name="survey-timeseries",
+    ),
     path("admin/", admin.site.urls),
 ]
 

--- a/iasc/views.py
+++ b/iasc/views.py
@@ -7,6 +7,7 @@ from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.db import transaction, IntegrityError
 from django.db.models import Count, Q
+from django.db.models.functions import TruncDate
 from django.http import HttpResponseRedirect
 from django_filters import rest_framework as filters
 from rest_framework import viewsets, permissions, status
@@ -668,6 +669,44 @@ class SurveyTemplateViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         return super().update(request, *args, **kwargs)
+
+
+class SurveyAggregateView(APIView):
+    """
+    GET /api/survey/<survey_id>/aggregate/
+    Returns vote_counts for a survey, optionally filtered by institution and/or discipline.
+    """
+
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def get(self, request, survey_id):
+        try:
+            survey = Survey.objects.get(pk=survey_id)
+        except Survey.DoesNotExist:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        results = Result.objects.filter(survey_id=survey_id)
+        institution_id = request.query_params.get("institution")
+        discipline_id = request.query_params.get("discipline")
+        if institution_id:
+            results = results.filter(institution_id=institution_id)
+        if discipline_id:
+            results = results.filter(discipline_id=discipline_id)
+
+        vote_counts = serializers.compute_vote_counts(results)
+        data = {
+            "id": survey.id,
+            "question": survey.question,
+            "questions": survey.questions,
+            "kind": survey.kind,
+            "active": survey.active,
+            "hide_title": survey.hide_title,
+            "participants": survey.participants,
+            "voted": survey.voted,
+            "count": results.count(),
+            "vote_counts": vote_counts,
+        }
+        return Response(serializers.SurveyAggregateSerializer(data).data)
 
 
 # Azure Healthcheck route

--- a/iasc/views.py
+++ b/iasc/views.py
@@ -742,10 +742,12 @@ class SurveyAggregateView(APIView):
             return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
 
         results = Result.objects.filter(survey_id=survey_id)
-        institution_id = request.query_params.get("institution")
+        institution_param = request.query_params.get("institution")
         discipline_id = request.query_params.get("discipline")
-        if institution_id:
-            results = results.filter(institution_id=institution_id)
+        if institution_param:
+            ids = [int(i) for i in institution_param.split(";") if i.strip().isdigit()]
+            if ids:
+                results = results.filter(institution_id__in=ids)
         if discipline_id:
             results = results.filter(discipline_id=discipline_id)
 

--- a/iasc/views.py
+++ b/iasc/views.py
@@ -671,6 +671,49 @@ class SurveyTemplateViewSet(viewsets.ModelViewSet):
         return super().update(request, *args, **kwargs)
 
 
+class SurveyTimeseriesView(APIView):
+    """
+    GET /api/survey/<survey_id>/timeseries/
+    Returns daily vote counts and cumulative totals for burn-up charting.
+    """
+
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def get(self, request, survey_id):
+        try:
+            survey = Survey.objects.get(pk=survey_id)
+        except Survey.DoesNotExist:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        rows = (
+            Result.objects.filter(survey_id=survey_id)
+            .annotate(date=TruncDate("added"))
+            .values("date")
+            .annotate(count=Count("id"))
+            .order_by("date")
+        )
+
+        series = []
+        cumulative = 0
+        for row in rows:
+            cumulative += row["count"]
+            series.append(
+                {
+                    "date": row["date"].isoformat(),
+                    "count": row["count"],
+                    "cumulative": cumulative,
+                }
+            )
+
+        return Response(
+            {
+                "participants": survey.participants,
+                "expiry": survey.expiry,
+                "series": series,
+            }
+        )
+
+
 class SurveyAggregateView(APIView):
     """
     GET /api/survey/<survey_id>/aggregate/

--- a/iasc/views.py
+++ b/iasc/views.py
@@ -519,9 +519,22 @@ class SurveyInstitutionViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         sid = self.kwargs["survey_id"]
+        # Include institutions that have active links OR results for this survey.
+        # Active-only filtering excludes closed surveys where all links are deleted.
+        from_links = Institution.objects.filter(
+            participant__activelink__survey_id=sid
+        ).values("id")
+        from_results = Institution.objects.filter(result__survey_id=sid).values("id")
+        institution_ids = from_links.union(from_results)
         return (
-            Institution.objects.filter(participant__activelink__survey_id=sid)
-            .annotate(link_count=Count("participant__activelink", distinct=True))
+            Institution.objects.filter(id__in=institution_ids)
+            .annotate(
+                link_count=Count(
+                    "participant__activelink",
+                    filter=Q(participant__activelink__survey_id=sid),
+                    distinct=True,
+                )
+            )
             .annotate(
                 voted_count=Count(
                     "result", filter=Q(result__survey_id=sid), distinct=True

--- a/react-app/src/App.jsx
+++ b/react-app/src/App.jsx
@@ -43,6 +43,9 @@ const DownloadParticipants = lazy(
       /* webpackChunkName: "dashboard" */ "./pages/download/DownloadParticipants"
     )
 );
+const ResultsView = lazy(
+  () => import(/* webpackChunkName: "results" */ "./pages/results/ResultsView")
+);
 
 /**
  * Display an error message if something goes wrong!
@@ -79,6 +82,10 @@ function App() {
                   <Route path="/error" element={<Error />} />
                   <Route path="/login" element={<Login />} />
                   <Route path="/dashboard" element={<Dashboard />} />
+                  <Route
+                    path="/dashboard/results/:surveyId"
+                    element={<ResultsView />}
+                  />
                   <Route path="/download" element={<DownloadParticipants />} />
                 </Routes>
                 <Footer />

--- a/react-app/src/components/DashboardTable.jsx
+++ b/react-app/src/components/DashboardTable.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useContext, useState } from "react";
+import { Link } from "react-router-dom";
 import Symbol from "./Symbol";
 import { client } from "../Api";
 import { MessageContext } from "./MessageHandler";
@@ -178,6 +179,9 @@ function DashboardTable({ reload, selectedSurveyId, onSelect }) {
                 />
               </td>
               <td className="no-mobile no-tablet">
+                <Link to={`/dashboard/results/${row.id}`}>
+                  <span className="material-symbols-outlined">bar_chart</span>
+                </Link>{" "}
                 <a href={`/api/result/xls/?survey=${row.id}`}>
                   <span className="material-symbols-outlined">download</span>
                 </a>

--- a/react-app/src/pages/results/ResultsView.jsx
+++ b/react-app/src/pages/results/ResultsView.jsx
@@ -1,0 +1,454 @@
+import React, { useEffect, useState, useContext } from "react";
+import { useParams, Link, Navigate } from "react-router-dom";
+import {
+  Chart as ChartJS,
+  ArcElement,
+  BarElement,
+  LineElement,
+  PointElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Legend,
+  Filler,
+} from "chart.js";
+import { Bar, Pie, Line } from "react-chartjs-2";
+import { client } from "../../Api";
+import { AuthContext } from "../../components/AuthContext";
+import "./results.css";
+
+ChartJS.register(
+  ArcElement,
+  BarElement,
+  LineElement,
+  PointElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Legend,
+  Filler
+);
+
+const VOTE_LABELS = {
+  1: "Strongly Agree",
+  2: "Agree",
+  3: "Neutral",
+  4: "Disagree",
+  5: "Strongly Disagree",
+};
+const LIKERT_COLORS = ["#1A5276", "#27AE60", "#95A5A6", "#E59866", "#C0392B"];
+const CHECKBOX_COLORS = ["#27AE60", "#E74C3C"];
+
+function buildLikertBarData(counts) {
+  const keys = ["1", "2", "3", "4", "5"];
+  return {
+    labels: keys.map((k) => VOTE_LABELS[k]),
+    datasets: [
+      {
+        label: "Votes",
+        data: keys.map((k) => counts[k] ?? 0),
+        backgroundColor: LIKERT_COLORS,
+      },
+    ],
+  };
+}
+
+function buildCheckboxPieData(counts) {
+  const yes = counts.True ?? counts.true ?? 0;
+  const no = counts.False ?? counts.false ?? 0;
+  return {
+    labels: [`Yes (${yes})`, `No (${no})`],
+    datasets: [{ data: [yes, no], backgroundColor: CHECKBOX_COLORS }],
+  };
+}
+
+const BAR_OPTIONS = {
+  indexAxis: "y",
+  responsive: true,
+  plugins: { legend: { display: false } },
+  scales: { x: { beginAtZero: true, ticks: { precision: 0 } } },
+};
+
+const PIE_OPTIONS = { plugins: { legend: { position: "bottom" } } };
+
+function likertStats(counts) {
+  const total = Object.values(counts).reduce((a, b) => a + b, 0);
+  if (total === 0) return null;
+  const agree = (counts["1"] ?? 0) + (counts["2"] ?? 0);
+  const disagree = (counts["4"] ?? 0) + (counts["5"] ?? 0);
+  const mean =
+    [1, 2, 3, 4, 5].reduce((s, k) => s + k * (counts[String(k)] ?? 0), 0) /
+    total;
+  return {
+    total,
+    agreePct: Math.round((agree / total) * 100),
+    disagreePct: Math.round((disagree / total) * 100),
+    mean: mean.toFixed(2),
+  };
+}
+
+function LikertBlock({ title, counts }) {
+  const stats = likertStats(counts);
+  return (
+    <div className="results--question-block">
+      <p className="results--question-title">{title}</p>
+      <Bar data={buildLikertBarData(counts)} options={BAR_OPTIONS} />
+      {stats && (
+        <div className="results--stats-row">
+          <span>
+            <strong>{stats.agreePct}%</strong> Agree
+          </span>
+          <span>
+            <strong>{stats.disagreePct}%</strong> Disagree
+          </span>
+          <span>
+            Mean <strong>{stats.mean}</strong>
+          </span>
+          <span>
+            n&nbsp;=&nbsp;<strong>{stats.total}</strong>
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CheckboxBlock({ title, counts }) {
+  const yes = counts.True ?? counts.true ?? 0;
+  const no = counts.False ?? counts.false ?? 0;
+  const total = yes + no;
+  return (
+    <div className="results--question-block results--question-block--checkbox">
+      <p className="results--question-title">{title}</p>
+      <div className="results--pie-wrap">
+        <Pie data={buildCheckboxPieData(counts)} options={PIE_OPTIONS} />
+      </div>
+      {total > 0 && (
+        <div className="results--stats-row">
+          <span>
+            <strong>{Math.round((yes / total) * 100)}%</strong> Yes
+          </span>
+          <span>
+            n&nbsp;=&nbsp;<strong>{total}</strong>
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function buildBurnupData(series, participants, expiry) {
+  const labels = series.map((p) => p.date);
+  const actual = series.map((p) => p.cumulative);
+
+  const datasets = [
+    {
+      label: "Votes received",
+      data: actual,
+      borderColor: "#1A5276",
+      backgroundColor: "rgba(26,82,118,0.1)",
+      fill: true,
+      tension: 0.3,
+    },
+    {
+      label: "Target",
+      data: labels.map(() => participants),
+      borderColor: "#95A5A6",
+      borderDash: [4, 4],
+      pointRadius: 0,
+      fill: false,
+    },
+  ];
+
+  if (expiry && series.length >= 2) {
+    const now = new Date();
+    const expiryDate = new Date(expiry);
+    if (expiryDate > now) {
+      const first = new Date(series[0].date);
+      const last = new Date(series[series.length - 1].date);
+      const daysElapsed = Math.max(1, (last - first) / (1000 * 60 * 60 * 24));
+      const slope = series[series.length - 1].cumulative / daysElapsed;
+      const daysToExpiry = Math.ceil(
+        (expiryDate - last) / (1000 * 60 * 60 * 24)
+      );
+
+      const trendLabels = [];
+      const trendData = [];
+      const lastCumulative = series[series.length - 1].cumulative;
+      for (let d = 1; d <= daysToExpiry; d += 1) {
+        const date = new Date(last);
+        date.setDate(date.getDate() + d);
+        trendLabels.push(date.toISOString().slice(0, 10));
+        trendData.push(
+          Math.min(participants, Math.round(lastCumulative + slope * d))
+        );
+      }
+
+      if (trendLabels.length > 0) {
+        const allLabels = [...labels, ...trendLabels];
+        const paddedActual = [
+          ...actual,
+          ...Array(trendLabels.length).fill(null),
+        ];
+        const paddedTarget = allLabels.map(() => participants);
+        const trendFull = [
+          ...Array(labels.length - 1).fill(null),
+          lastCumulative,
+          ...trendData,
+        ];
+        datasets[0].data = paddedActual;
+        datasets[1].data = paddedTarget;
+        datasets.push({
+          label: "Trend",
+          data: trendFull,
+          borderColor: "#E59866",
+          borderDash: [6, 3],
+          pointRadius: 0,
+          fill: false,
+        });
+        return { labels: allLabels, datasets };
+      }
+    }
+  }
+
+  return { labels, datasets };
+}
+
+function BurnupChart({ surveyId, participants, expiry }) {
+  const [series, setSeries] = useState(null);
+
+  useEffect(() => {
+    client
+      .get(`/api/survey/${surveyId}/timeseries/`)
+      .then((r) => setSeries(r.data.series))
+      .catch(() => setSeries([]));
+  }, [surveyId]);
+
+  if (series === null)
+    return <p className="results--loading">Loading chart…</p>;
+  if (series.length === 0)
+    return <p className="results--empty">No votes yet.</p>;
+
+  const chartData = buildBurnupData(series, participants, expiry);
+  return (
+    <Line
+      data={chartData}
+      options={{
+        responsive: true,
+        plugins: { legend: { position: "bottom" } },
+        scales: {
+          y: {
+            beginAtZero: true,
+            max: participants,
+            ticks: { precision: 0 },
+          },
+        },
+      }}
+    />
+  );
+}
+
+function InstitutionTable({ surveyId, onSelect, selectedId }) {
+  const [institutions, setInstitutions] = useState(null);
+
+  useEffect(() => {
+    client
+      .get(`/api/survey/${surveyId}/institutions/`)
+      .then((r) => setInstitutions(r.data.results))
+      .catch(() => setInstitutions([]));
+  }, [surveyId]);
+
+  if (institutions === null)
+    return <p className="results--loading">Loading…</p>;
+  if (institutions.length === 0) return null;
+
+  return (
+    <table className="results--institution-table">
+      <thead>
+        <tr>
+          <th>Institution</th>
+          <th>Voted</th>
+          <th>Total invited</th>
+          <th>Response rate</th>
+        </tr>
+      </thead>
+      <tbody>
+        {institutions.map((inst) => (
+          <tr
+            key={inst.id}
+            className={`results--inst-row${selectedId === inst.id ? " selected" : ""}`}
+            onClick={() => onSelect(selectedId === inst.id ? null : inst.id)}
+          >
+            <td>{inst.name}</td>
+            <td>{inst.total_count - inst.link_count}</td>
+            <td>{inst.total_count}</td>
+            <td>
+              {inst.total_count > 0
+                ? `${Math.round(((inst.total_count - inst.link_count) / inst.total_count) * 100)}%`
+                : "—"}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export default function ResultsView() {
+  const { surveyId } = useParams();
+  const { isAuth } = useContext(AuthContext);
+  const isLocal = process.env.NODE_ENV === "development";
+
+  const [survey, setSurvey] = useState(null);
+  const [aggregate, setAggregate] = useState(null);
+  const [selectedInstitution, setSelectedInstitution] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const fetchAggregate = (institutionId) => {
+    const params = institutionId ? `?institution=${institutionId}` : "";
+    return client
+      .get(`/api/survey/${surveyId}/aggregate/${params}`)
+      .then((r) => setAggregate(r.data));
+  };
+
+  useEffect(() => {
+    client
+      .get(`/api/survey/${surveyId}/`)
+      .then((r) => {
+        setSurvey(r.data);
+        return fetchAggregate(null);
+      })
+      .catch((e) =>
+        setError(e.response?.status === 404 ? "not_found" : "error")
+      )
+      .finally(() => setLoading(false));
+  }, [surveyId]);
+
+  const handleInstitutionSelect = (id) => {
+    setSelectedInstitution(id);
+    fetchAggregate(id);
+  };
+
+  if (!isAuth && !isLocal) return <Navigate to="/login" />;
+  if (loading)
+    return (
+      <div className="container">
+        <p className="results--loading">Loading…</p>
+      </div>
+    );
+  if (error === "not_found")
+    return (
+      <div className="container">
+        <p>
+          Survey not found. <Link to="/dashboard">Back to dashboard</Link>
+        </p>
+      </div>
+    );
+  if (error || !survey || !aggregate)
+    return (
+      <div className="container">
+        <p>
+          Failed to load results. <Link to="/dashboard">Back to dashboard</Link>
+        </p>
+      </div>
+    );
+
+  const slots = aggregate.template_slots ?? [];
+  const questions = aggregate.questions ?? [];
+  const voteCounts = aggregate.vote_counts ?? {};
+  const responseRate =
+    survey.participants > 0
+      ? Math.round((survey.voted / survey.participants) * 100)
+      : 0;
+
+  let likertIdx = 0;
+  const chartBlocks = slots.map((slot, i) => {
+    if (slot.type === "likert") {
+      const key = String(likertIdx);
+      const title = questions[likertIdx] ?? `Statement ${likertIdx + 1}`;
+      likertIdx += 1;
+      const counts = voteCounts[key] ?? {};
+      return <LikertBlock key={slot.id} title={title} counts={counts} />;
+    }
+    if (slot.type === "checkbox") {
+      const counts = voteCounts[String(i)] ?? {};
+      return (
+        <CheckboxBlock
+          key={slot.id}
+          title={questions[i] ?? slot.placeholder}
+          counts={counts}
+        />
+      );
+    }
+    return null;
+  });
+
+  // Single-LI survey: vote_counts is a flat {1: n, 2: n, ...}
+  const isSingleLikert = slots.length <= 1;
+  const singleLikertBlock = isSingleLikert && (
+    <LikertBlock title={survey.question} counts={voteCounts} />
+  );
+
+  return (
+    <div className="container">
+      <div className="results--page">
+        <div className="results--header">
+          <Link to="/dashboard" className="results--back">
+            ← Back to dashboard
+          </Link>
+          <h1 className="results--title">{survey.question}</h1>
+          <div className="results--meta">
+            <span className="results--kind-badge">{survey.kind}</span>
+            <span className="results--response-rate">
+              {survey.voted} / {survey.participants} responses ({responseRate}%)
+            </span>
+          </div>
+          <div className="results--progress-bar">
+            <div
+              className="results--progress-fill"
+              style={{ width: `${responseRate}%` }}
+            />
+          </div>
+          {selectedInstitution && (
+            <p className="results--filter-notice">
+              Showing results for selected institution.{" "}
+              <button
+                type="button"
+                className="results--clear-filter"
+                onClick={() => handleInstitutionSelect(null)}
+              >
+                Show all
+              </button>
+            </p>
+          )}
+        </div>
+
+        <div className="results--charts">
+          {isSingleLikert ? singleLikertBlock : chartBlocks}
+        </div>
+
+        <section className="results--section">
+          <h2>Votes over time</h2>
+          <BurnupChart
+            surveyId={Number(surveyId)}
+            participants={survey.participants}
+            expiry={survey.expiry}
+          />
+        </section>
+
+        <section className="results--section">
+          <h2>Response rate by institution</h2>
+          <p className="results--inst-hint">
+            Click a row to filter charts to that institution.
+          </p>
+          <InstitutionTable
+            surveyId={Number(surveyId)}
+            onSelect={handleInstitutionSelect}
+            selectedId={selectedInstitution}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/react-app/src/pages/results/ResultsView.jsx
+++ b/react-app/src/pages/results/ResultsView.jsx
@@ -248,7 +248,7 @@ function BurnupChart({ surveyId, participants, expiry }) {
   );
 }
 
-function InstitutionPanel({ surveyId, onSelect, selectedId }) {
+function InstitutionPanel({ surveyId, onSelect, selectedIds }) {
   const [institutions, setInstitutions] = useState(null);
 
   useEffect(() => {
@@ -267,12 +267,14 @@ function InstitutionPanel({ surveyId, onSelect, selectedId }) {
 
   return (
     <div className="results--inst-panel">
-      <p className="results--inst-hint">Click a row to filter charts.</p>
-      {selectedId && (
+      <p className="results--inst-hint">
+        Click to filter. Shift+click to select multiple.
+      </p>
+      {selectedIds.size > 0 && (
         <button
           type="button"
           className="results--clear-filter"
-          onClick={() => onSelect(null)}
+          onClick={() => onSelect(null, false)}
         >
           ✕ Clear filter
         </button>
@@ -294,10 +296,8 @@ function InstitutionPanel({ surveyId, onSelect, selectedId }) {
             return (
               <tr
                 key={inst.id}
-                className={`results--inst-row${selectedId === inst.id ? " selected" : ""}`}
-                onClick={() =>
-                  onSelect(selectedId === inst.id ? null : inst.id)
-                }
+                className={`results--inst-row${selectedIds.has(inst.id) ? " selected" : ""}`}
+                onClick={(e) => onSelect(inst.id, e.shiftKey)}
               >
                 <td>{inst.name}</td>
                 <td>
@@ -319,12 +319,12 @@ export default function ResultsView() {
 
   const [survey, setSurvey] = useState(null);
   const [aggregate, setAggregate] = useState(null);
-  const [selectedInstitution, setSelectedInstitution] = useState(null);
+  const [selectedInstitutions, setSelectedInstitutions] = useState(new Set());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const fetchAggregate = (institutionId) => {
-    const params = institutionId ? `?institution=${institutionId}` : "";
+  const fetchAggregate = (ids) => {
+    const params = ids.size > 0 ? `?institution=${[...ids].join(";")}` : "";
     return client
       .get(`/api/survey/${surveyId}/aggregate/${params}`)
       .then((r) => setAggregate(r.data));
@@ -335,7 +335,7 @@ export default function ResultsView() {
       .get(`/api/survey/${surveyId}/`)
       .then((r) => {
         setSurvey(r.data);
-        return fetchAggregate(null);
+        return fetchAggregate(new Set());
       })
       .catch((e) =>
         setError(e.response?.status === 404 ? "not_found" : "error")
@@ -343,9 +343,23 @@ export default function ResultsView() {
       .finally(() => setLoading(false));
   }, [surveyId]);
 
-  const handleInstitutionSelect = (id) => {
-    setSelectedInstitution(id);
-    fetchAggregate(id);
+  const handleInstitutionSelect = (id, isShift) => {
+    // null id = clear all
+    if (id === null) {
+      setSelectedInstitutions(new Set());
+      fetchAggregate(new Set());
+      return;
+    }
+    setSelectedInstitutions((prev) => {
+      const next = isShift ? new Set(prev) : new Set();
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      fetchAggregate(next);
+      return next;
+    });
   };
 
   if (!isAuth && !isLocal) return <Navigate to="/login" />;
@@ -437,7 +451,7 @@ export default function ResultsView() {
             <InstitutionPanel
               surveyId={Number(surveyId)}
               onSelect={handleInstitutionSelect}
-              selectedId={selectedInstitution}
+              selectedIds={selectedInstitutions}
             />
           </aside>
 
@@ -448,11 +462,13 @@ export default function ResultsView() {
 
             <section className="results--section">
               <h2>Votes over time</h2>
-              <BurnupChart
-                surveyId={Number(surveyId)}
-                participants={survey.participants}
-                expiry={survey.expiry}
-              />
+              <div className="results--question-block">
+                <BurnupChart
+                  surveyId={Number(surveyId)}
+                  participants={survey.participants}
+                  expiry={survey.expiry}
+                />
+              </div>
             </section>
           </div>
         </div>

--- a/react-app/src/pages/results/ResultsView.jsx
+++ b/react-app/src/pages/results/ResultsView.jsx
@@ -248,7 +248,7 @@ function BurnupChart({ surveyId, participants, expiry }) {
   );
 }
 
-function InstitutionTable({ surveyId, onSelect, selectedId }) {
+function InstitutionPanel({ surveyId, onSelect, selectedId }) {
   const [institutions, setInstitutions] = useState(null);
 
   useEffect(() => {
@@ -260,37 +260,55 @@ function InstitutionTable({ surveyId, onSelect, selectedId }) {
 
   if (institutions === null)
     return <p className="results--loading">Loading…</p>;
-  if (institutions.length === 0) return null;
+  if (institutions.length === 0)
+    return (
+      <p className="results--empty">No institution breakdown available.</p>
+    );
 
   return (
-    <table className="results--institution-table">
-      <thead>
-        <tr>
-          <th>Institution</th>
-          <th>Voted</th>
-          <th>Total invited</th>
-          <th>Response rate</th>
-        </tr>
-      </thead>
-      <tbody>
-        {institutions.map((inst) => (
-          <tr
-            key={inst.id}
-            className={`results--inst-row${selectedId === inst.id ? " selected" : ""}`}
-            onClick={() => onSelect(selectedId === inst.id ? null : inst.id)}
-          >
-            <td>{inst.name}</td>
-            <td>{inst.total_count - inst.link_count}</td>
-            <td>{inst.total_count}</td>
-            <td>
-              {inst.total_count > 0
-                ? `${Math.round(((inst.total_count - inst.link_count) / inst.total_count) * 100)}%`
-                : "—"}
-            </td>
+    <div className="results--inst-panel">
+      <p className="results--inst-hint">Click a row to filter charts.</p>
+      {selectedId && (
+        <button
+          type="button"
+          className="results--clear-filter"
+          onClick={() => onSelect(null)}
+        >
+          ✕ Clear filter
+        </button>
+      )}
+      <table className="results--institution-table">
+        <thead>
+          <tr>
+            <th>Institution</th>
+            <th>Rate</th>
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {institutions.map((inst) => {
+            const voted = inst.total_count - inst.link_count;
+            const rate =
+              inst.total_count > 0
+                ? `${Math.round((voted / inst.total_count) * 100)}%`
+                : "—";
+            return (
+              <tr
+                key={inst.id}
+                className={`results--inst-row${selectedId === inst.id ? " selected" : ""}`}
+                onClick={() =>
+                  onSelect(selectedId === inst.id ? null : inst.id)
+                }
+              >
+                <td>{inst.name}</td>
+                <td>
+                  {voted}/{inst.total_count} ({rate})
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
   );
 }
 
@@ -410,44 +428,34 @@ export default function ResultsView() {
               style={{ width: `${responseRate}%` }}
             />
           </div>
-          {selectedInstitution && (
-            <p className="results--filter-notice">
-              Showing results for selected institution.{" "}
-              <button
-                type="button"
-                className="results--clear-filter"
-                onClick={() => handleInstitutionSelect(null)}
-              >
-                Show all
-              </button>
-            </p>
-          )}
         </div>
 
-        <div className="results--charts">
-          {isSingleLikert ? singleLikertBlock : chartBlocks}
+        <div className="results--body">
+          <aside className="results--sidebar">
+            <p className="results--section-header">Filter by institution</p>
+            <hr />
+            <InstitutionPanel
+              surveyId={Number(surveyId)}
+              onSelect={handleInstitutionSelect}
+              selectedId={selectedInstitution}
+            />
+          </aside>
+
+          <div className="results--main">
+            <div className="results--charts">
+              {isSingleLikert ? singleLikertBlock : chartBlocks}
+            </div>
+
+            <section className="results--section">
+              <h2>Votes over time</h2>
+              <BurnupChart
+                surveyId={Number(surveyId)}
+                participants={survey.participants}
+                expiry={survey.expiry}
+              />
+            </section>
+          </div>
         </div>
-
-        <section className="results--section">
-          <h2>Votes over time</h2>
-          <BurnupChart
-            surveyId={Number(surveyId)}
-            participants={survey.participants}
-            expiry={survey.expiry}
-          />
-        </section>
-
-        <section className="results--section">
-          <h2>Response rate by institution</h2>
-          <p className="results--inst-hint">
-            Click a row to filter charts to that institution.
-          </p>
-          <InstitutionTable
-            surveyId={Number(surveyId)}
-            onSelect={handleInstitutionSelect}
-            selectedId={selectedInstitution}
-          />
-        </section>
       </div>
     </div>
   );

--- a/react-app/src/pages/results/results.css
+++ b/react-app/src/pages/results/results.css
@@ -1,0 +1,166 @@
+.results--page {
+  padding: 2rem 0;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.results--back {
+  display: inline-block;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+.results--title {
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+
+.results--meta {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.results--kind-badge {
+  background: #14213d;
+  color: #fff;
+  border-radius: 4px;
+  padding: 0.15rem 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.results--response-rate {
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.results--progress-bar {
+  width: 100%;
+  height: 8px;
+  background: #e0e0e0;
+  border-radius: 4px;
+  margin-bottom: 0.75rem;
+  overflow: hidden;
+}
+
+.results--progress-fill {
+  height: 100%;
+  background: #27ae60;
+  border-radius: 4px;
+  transition: width 0.4s ease;
+}
+
+.results--filter-notice {
+  font-size: 0.85rem;
+  color: #666;
+  margin-bottom: 0.5rem;
+}
+
+.results--clear-filter {
+  background: none;
+  border: none;
+  color: #3c096c;
+  cursor: pointer;
+  text-decoration: underline;
+  font-size: 0.85rem;
+  padding: 0;
+}
+
+.results--charts {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+  gap: 2rem;
+  margin: 2rem 0;
+}
+
+.results--question-block {
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 1.25rem;
+}
+
+.results--question-block--checkbox {
+  max-width: 400px;
+}
+
+.results--question-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+  color: #14213d;
+}
+
+.results--pie-wrap {
+  max-width: 260px;
+  margin: 0 auto;
+}
+
+.results--stats-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 0.75rem;
+  font-size: 0.85rem;
+  color: #555;
+}
+
+.results--section {
+  margin-top: 2.5rem;
+}
+
+.results--section h2 {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.results--inst-hint {
+  font-size: 0.85rem;
+  color: #777;
+  margin-bottom: 0.5rem;
+}
+
+.results--institution-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.results--institution-table th,
+.results--institution-table td {
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.results--institution-table th {
+  font-weight: 600;
+  background: #f5f5f5;
+}
+
+.results--inst-row {
+  cursor: pointer;
+}
+
+.results--inst-row:hover {
+  background: #f0f4ff;
+}
+
+.results--inst-row.selected {
+  background: #dde8ff;
+}
+
+.results--loading {
+  color: #999;
+  font-size: 0.9rem;
+  margin: 1rem 0;
+}
+
+.results--empty {
+  color: #999;
+  font-size: 0.9rem;
+}

--- a/react-app/src/pages/results/results.css
+++ b/react-app/src/pages/results/results.css
@@ -1,13 +1,15 @@
 .results--page {
-  padding: 2rem 0;
-  max-width: 960px;
-  margin: 0 auto;
+  padding: 1rem 4rem 2rem 4rem;
 }
 
 .results--back {
   display: inline-block;
   margin-bottom: 1rem;
   font-size: 0.9rem;
+}
+
+.results--header {
+  margin-bottom: 1.5rem;
 }
 
 .results--title {
@@ -42,7 +44,6 @@
   height: 8px;
   background: #e0e0e0;
   border-radius: 4px;
-  margin-bottom: 0.75rem;
   overflow: hidden;
 }
 
@@ -53,27 +54,108 @@
   transition: width 0.4s ease;
 }
 
-.results--filter-notice {
-  font-size: 0.85rem;
+/* ── Two-column body ────────────────────────────────────────── */
+
+.results--body {
+  display: flex;
+  width: 100%;
+  gap: 0;
+}
+
+.results--sidebar {
+  width: 30vw;
+  flex-shrink: 0;
+  padding: 1rem;
+  box-sizing: border-box;
+}
+
+.results--section-header {
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0 0 0.5rem 0;
   color: #666;
-  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.results--sidebar hr {
+  border: none;
+  border-top: 2px solid #e0e0e0;
+  margin-bottom: 1rem;
+}
+
+.results--main {
+  flex: 1;
+  min-width: 0;
+  padding: 1rem;
+  box-sizing: border-box;
+}
+
+/* ── Institution panel (sidebar) ────────────────────────────── */
+
+.results--inst-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.results--inst-hint {
+  font-size: 0.85rem;
+  color: #777;
 }
 
 .results--clear-filter {
   background: none;
-  border: none;
+  border: 1px solid #3c096c;
   color: #3c096c;
   cursor: pointer;
-  text-decoration: underline;
-  font-size: 0.85rem;
-  padding: 0;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 3px;
+  align-self: flex-start;
 }
+
+.results--clear-filter:hover {
+  background: #f0e8ff;
+}
+
+.results--institution-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.results--institution-table th,
+.results--institution-table td {
+  padding: 0.4rem 0.5rem;
+  text-align: left;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.results--institution-table th {
+  font-weight: 600;
+  background: #f5f5f5;
+}
+
+.results--inst-row {
+  cursor: pointer;
+}
+
+.results--inst-row:hover {
+  background: #f0f4ff;
+}
+
+.results--inst-row.selected {
+  background: #dde8ff;
+}
+
+/* ── Charts area (main column) ──────────────────────────────── */
 
 .results--charts {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
-  gap: 2rem;
-  margin: 2rem 0;
+  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
 }
 
 .results--question-block {
@@ -109,7 +191,7 @@
 }
 
 .results--section {
-  margin-top: 2.5rem;
+  margin-top: 2rem;
 }
 
 .results--section h2 {
@@ -118,41 +200,7 @@
   margin-bottom: 1rem;
 }
 
-.results--inst-hint {
-  font-size: 0.85rem;
-  color: #777;
-  margin-bottom: 0.5rem;
-}
-
-.results--institution-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.9rem;
-}
-
-.results--institution-table th,
-.results--institution-table td {
-  padding: 0.5rem 0.75rem;
-  text-align: left;
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.results--institution-table th {
-  font-weight: 600;
-  background: #f5f5f5;
-}
-
-.results--inst-row {
-  cursor: pointer;
-}
-
-.results--inst-row:hover {
-  background: #f0f4ff;
-}
-
-.results--inst-row.selected {
-  background: #dde8ff;
-}
+/* ── Utility ─────────────────────────────────────────────────── */
 
 .results--loading {
   color: #999;
@@ -163,4 +211,29 @@
 .results--empty {
   color: #999;
   font-size: 0.9rem;
+}
+
+/* ── Mobile: single column ──────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .results--page {
+    padding: 1rem;
+  }
+
+  .results--body {
+    flex-direction: column;
+  }
+
+  .results--sidebar {
+    width: 100%;
+    padding: 0.5rem 0;
+  }
+
+  .results--main {
+    padding: 0.5rem 0;
+  }
+
+  .results--charts {
+    grid-template-columns: 1fr;
+  }
 }

--- a/react-app/src/pages/results/results.css
+++ b/react-app/src/pages/results/results.css
@@ -1,4 +1,5 @@
 .results--page {
+  width: 100%;
   padding: 1rem 4rem 2rem 4rem;
 }
 

--- a/react-app/src/pages/results/results.css
+++ b/react-app/src/pages/results/results.css
@@ -41,6 +41,7 @@
 }
 
 .results--progress-bar {
+  position: relative;
   width: 100%;
   height: 8px;
   background: #e0e0e0;
@@ -49,6 +50,9 @@
 }
 
 .results--progress-fill {
+  position: absolute;
+  top: 0;
+  left: 0;
   height: 100%;
   background: #27ae60;
   border-radius: 4px;

--- a/react-app/webpack.config.js
+++ b/react-app/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = {
     filename: "[name]-[chunkhash].js",
     chunkFilename: "[name]-[chunkhash].bundle.js",
     path: path.resolve("../frontend/static/dist/"),
-    publicPath: "static/dist/",
+    publicPath: "/static/dist/",
   },
   plugins: [
     new CleanWebpackPlugin(),


### PR DESCRIPTION
## Summary

- Adds `GET /api/survey/<id>/aggregate/` — returns vote counts filtered by institution(s) and/or discipline
- Adds `GET /api/survey/<id>/timeseries/` — daily cumulative vote counts for the burn-up chart
- Adds discipline filter to `ResultFilter`
- New `ResultsView` page at `/dashboard/results/:surveyId` with horizontal bar charts (Likert), pie charts (checkbox), institution breakdown sidebar with multi-select filtering (shift+click), and a burn-up chart with trend projection
- Dashboard results table links directly to the new results page
- Fixes `publicPath` to be absolute so webpack chunks load correctly at depth-2 routes
- Fixes institution breakdown for closed surveys (unions active links + results)
- Fixes direct navigation 404 (`frontend/urls.py` route + lambda to discard captured kwarg)

Addresses #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)