### PR TITLE
Dashboard fixes (#111)

### DIFF
--- a/iasc/fixtures/Survey.json
+++ b/iasc/fixtures/Survey.json
@@ -62,7 +62,8 @@
       "question": "Rate your views on research software and state your expertise.",
       "questions": [
         "Research software should be treated as a first-class research output",
-        "Current training for research software development is adequate"
+        "Current training for research software development is adequate",
+        "I have relevant expertise in research software"
       ],
       "active": true,
       "kind": "L2E",
@@ -79,7 +80,8 @@
       "question": "Rate your views on data management and state your expertise.",
       "questions": [
         "FAIR data principles are well understood in my field",
-        "Institutional data management support is sufficient"
+        "Institutional data management support is sufficient",
+        "I have relevant expertise in data management"
       ],
       "active": false,
       "kind": "L2E",

--- a/react-app/src/components/DashboardTable.jsx
+++ b/react-app/src/components/DashboardTable.jsx
@@ -127,86 +127,92 @@ function DashboardTable({ reload, selectedSurveyId, onSelect }) {
       </div>
 
       {/* Display Table body by mapping questionDatabase */}
-      <table className="dashboard--question--table">
-        <thead>
-          <tr>
-            <th className="no-mobile no-tablet">Statement</th>
-            <th>ID</th>
-            <th className="no-mobile">Type</th>
-            <th>Completed</th>
-            <th className="no-mobile">Links</th>
-            <th>Expiry</th>
-            <th>Active</th>
-            <th>Results</th>
-          </tr>
-        </thead>
-        <tbody>
-          {questionDatabase.map((row) => (
-            <tr
-              key={row.id}
-              className={`survey-row${selectedSurveyId === row.id ? " selected" : ""}`}
-              onClick={() =>
-                onSelect(
-                  row.id === selectedSurveyId ? null : row.id,
-                  row.id === selectedSurveyId ? null : row.question
-                )
-              }
-            >
-              <td className="no-mobile no-tablet">
-                {row.question.substring(0, 50)}
-                {row.question.length > 50 && "..."}
-              </td>
-              <td>{row.id}</td>
-              <td className="no-mobile">
-                <span className="dashboard--kind-badge">
-                  {definitions[row.kind]?.label ?? row.kind}
-                </span>
-              </td>
-              <td>
-                {(() => {
-                  const pct = Math.round((row.voted * 100) / row.participants);
-                  return (
-                    <div className="dashboard--completion">
-                      <span className="dashboard--completion-pct">{pct}%</span>
-                      <div className="dashboard--progress-bar">
-                        <div
-                          className="dashboard--progress-fill"
-                          style={{ width: `${pct}%` }}
-                        />
-                      </div>
-                    </div>
-                  );
-                })()}
-              </td>
-              <td className="no-mobile">
-                <a href={`/download?pollId=${row.id}`}>
-                  <span className="material-symbols-outlined">groups</span>
-                </a>
-              </td>
-              <td>{row.expiry.slice(0, 10)}</td>
-              <td>
-                <Symbol
-                  isActive={row.active}
-                  surveyId={row.id}
-                  activeSymbol="stop_circle"
-                  inactiveSymbol="close"
-                  onChange={(value) => {
-                    updateData(row.id, value);
-                  }}
-                />
-              </td>
-              <td>
-                <Link to={`/dashboard/results/${row.id}`}>
-                  <span className="material-symbols-outlined">bar_chart</span>
-                </Link>{" "}
-                <a href={`/api/result/xls/?survey=${row.id}`}>
-                  <span className="material-symbols-outlined">download</span>
-                </a>
-              </td>
+      <div className="dashboard--table-scroll">
+        <table className="dashboard--question--table">
+          <thead>
+            <tr>
+              <th className="no-mobile no-tablet">Statement</th>
+              <th>ID</th>
+              <th className="no-mobile">Type</th>
+              <th>Completed</th>
+              <th className="no-mobile">Links</th>
+              <th>Expiry</th>
+              <th>Active</th>
+              <th>Results</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {questionDatabase.map((row) => (
+              <tr
+                key={row.id}
+                className={`survey-row${selectedSurveyId === row.id ? " selected" : ""}`}
+                onClick={() =>
+                  onSelect(
+                    row.id === selectedSurveyId ? null : row.id,
+                    row.id === selectedSurveyId ? null : row.question
+                  )
+                }
+              >
+                <td className="no-mobile no-tablet">
+                  {row.question.substring(0, 50)}
+                  {row.question.length > 50 && "..."}
+                </td>
+                <td>{row.id}</td>
+                <td className="no-mobile">
+                  <span className="dashboard--kind-badge">
+                    {definitions[row.kind]?.label ?? row.kind}
+                  </span>
+                </td>
+                <td>
+                  {(() => {
+                    const pct = Math.round(
+                      (row.voted * 100) / row.participants
+                    );
+                    return (
+                      <div className="dashboard--completion">
+                        <span className="dashboard--completion-pct">
+                          {pct}%
+                        </span>
+                        <div className="dashboard--progress-bar">
+                          <div
+                            className="dashboard--progress-fill"
+                            style={{ width: `${pct}%` }}
+                          />
+                        </div>
+                      </div>
+                    );
+                  })()}
+                </td>
+                <td className="no-mobile">
+                  <a href={`/download?pollId=${row.id}`}>
+                    <span className="material-symbols-outlined">groups</span>
+                  </a>
+                </td>
+                <td>{row.expiry.slice(0, 10)}</td>
+                <td>
+                  <Symbol
+                    isActive={row.active}
+                    surveyId={row.id}
+                    activeSymbol="stop_circle"
+                    inactiveSymbol="close"
+                    onChange={(value) => {
+                      updateData(row.id, value);
+                    }}
+                  />
+                </td>
+                <td>
+                  <Link to={`/dashboard/results/${row.id}`}>
+                    <span className="material-symbols-outlined">bar_chart</span>
+                  </Link>{" "}
+                  <a href={`/api/result/xls/?survey=${row.id}`}>
+                    <span className="material-symbols-outlined">download</span>
+                  </a>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
 
       {/* Pagination: navigate data by setting page */}
       <div className="dashboard--next--page">

--- a/react-app/src/components/DashboardTable.jsx
+++ b/react-app/src/components/DashboardTable.jsx
@@ -159,9 +159,7 @@ function DashboardTable({ reload, selectedSurveyId, onSelect }) {
                 </td>
                 <td>{row.id}</td>
                 <td className="no-mobile">
-                  <span className="dashboard--kind-badge">
-                    {definitions[row.kind]?.label ?? row.kind}
-                  </span>
+                  {definitions[row.kind]?.label ?? row.kind}
                 </td>
                 <td>
                   {(() => {

--- a/react-app/src/components/DashboardTable.jsx
+++ b/react-app/src/components/DashboardTable.jsx
@@ -135,9 +135,9 @@ function DashboardTable({ reload, selectedSurveyId, onSelect }) {
               <th>ID</th>
               <th className="no-mobile">Type</th>
               <th>Completed</th>
-              <th className="no-mobile">Links</th>
               <th>Expiry</th>
               <th>Active</th>
+              <th className="no-mobile">Links</th>
               <th>Results</th>
             </tr>
           </thead>
@@ -181,11 +181,6 @@ function DashboardTable({ reload, selectedSurveyId, onSelect }) {
                     );
                   })()}
                 </td>
-                <td className="no-mobile">
-                  <a href={`/download?pollId=${row.id}`}>
-                    <span className="material-symbols-outlined">groups</span>
-                  </a>
-                </td>
                 <td>{row.expiry.slice(0, 10)}</td>
                 <td>
                   <Symbol
@@ -197,6 +192,11 @@ function DashboardTable({ reload, selectedSurveyId, onSelect }) {
                       updateData(row.id, value);
                     }}
                   />
+                </td>
+                <td className="no-mobile">
+                  <a href={`/download?pollId=${row.id}`}>
+                    <span className="material-symbols-outlined">groups</span>
+                  </a>
                 </td>
                 <td>
                   <Link to={`/dashboard/results/${row.id}`}>

--- a/react-app/src/components/DashboardTable.jsx
+++ b/react-app/src/components/DashboardTable.jsx
@@ -137,7 +137,7 @@ function DashboardTable({ reload, selectedSurveyId, onSelect }) {
             <th className="no-mobile">Links</th>
             <th>Expiry</th>
             <th>Active</th>
-            <th className="no-mobile no-tablet">Results</th>
+            <th>Results</th>
           </tr>
         </thead>
         <tbody>
@@ -178,7 +178,7 @@ function DashboardTable({ reload, selectedSurveyId, onSelect }) {
                   }}
                 />
               </td>
-              <td className="no-mobile no-tablet">
+              <td>
                 <Link to={`/dashboard/results/${row.id}`}>
                   <span className="material-symbols-outlined">bar_chart</span>
                 </Link>{" "}

--- a/react-app/src/components/DashboardTable.jsx
+++ b/react-app/src/components/DashboardTable.jsx
@@ -158,9 +158,26 @@ function DashboardTable({ reload, selectedSurveyId, onSelect }) {
               </td>
               <td>{row.id}</td>
               <td className="no-mobile">
-                {definitions[row.kind]?.label ?? row.kind}
+                <span className="dashboard--kind-badge">
+                  {definitions[row.kind]?.label ?? row.kind}
+                </span>
               </td>
-              <td>{Math.round((row.voted * 100) / row.participants)}%</td>
+              <td>
+                {(() => {
+                  const pct = Math.round((row.voted * 100) / row.participants);
+                  return (
+                    <div className="dashboard--completion">
+                      <span className="dashboard--completion-pct">{pct}%</span>
+                      <div className="dashboard--progress-bar">
+                        <div
+                          className="dashboard--progress-fill"
+                          style={{ width: `${pct}%` }}
+                        />
+                      </div>
+                    </div>
+                  );
+                })()}
+              </td>
               <td className="no-mobile">
                 <a href={`/download?pollId=${row.id}`}>
                   <span className="material-symbols-outlined">groups</span>

--- a/react-app/src/pages/dashboard/dashboard.css
+++ b/react-app/src/pages/dashboard/dashboard.css
@@ -152,6 +152,49 @@
   border: 2px solid #e0e0e0;
 }
 
+/* ── Backported from results page ────────────────────────────── */
+
+.dashboard--kind-badge {
+  background: #14213d;
+  color: #fff;
+  border-radius: 4px;
+  padding: 0.15rem 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.dashboard--completion {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  min-width: 4rem;
+}
+
+.dashboard--completion-pct {
+  font-size: 0.85rem;
+}
+
+.dashboard--progress-bar {
+  position: relative;
+  width: 100%;
+  height: 6px;
+  background: #e0e0e0;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.dashboard--progress-fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  background: #27ae60;
+  border-radius: 4px;
+  transition: width 0.4s ease;
+}
+
 .pie-chart--placeholder {
   color: #999;
   font-size: 0.95rem;

--- a/react-app/src/pages/dashboard/dashboard.css
+++ b/react-app/src/pages/dashboard/dashboard.css
@@ -304,13 +304,31 @@
   align-items: center;
 }
 
+.dashboard--table-scroll {
+  width: 100%;
+  overflow-x: auto;
+  border-radius: 8px;
+  border: 1px solid #e0e0e0;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(0, 0, 0, 0.5) #f5f5f5;
+}
+
+.dashboard--table-scroll::-webkit-scrollbar {
+  height: 8px;
+}
+
+.dashboard--table-scroll::-webkit-scrollbar-thumb {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.dashboard--table-scroll::-webkit-scrollbar-track {
+  background-color: #f5f5f5;
+}
+
 .dashboard--question--table {
   width: 100%;
   background: #fff;
-  border-radius: 8px;
-  border: 1px solid #e0e0e0;
-  border-collapse: separate;
-  border-spacing: 0;
+  border-collapse: collapse;
 }
 
 .dashboard--question--table::-webkit-scrollbar {
@@ -336,23 +354,6 @@
   align-items: center;
   text-align: center;
   font-size: 1rem;
-}
-
-.dashboard--question--table::-webkit-scrollbar {
-  width: 8px; /* Width of the scrollbar */
-}
-
-.dashboard--question--table::-webkit-scrollbar-thumb {
-  background-color: rgba(0, 0, 0, 0.5); /* Color of the scrollbar thumb */
-}
-
-.dashboard--question--table::-webkit-scrollbar-track {
-  background-color: #f5f5f5; /* Color of the scrollbar track */
-}
-
-.dashboard--question--table {
-  scrollbar-width: thin;
-  scrollbar-color: rgba(0, 0, 0, 0.5) #f5f5f5;
 }
 
 .dashboard--question--table thead tr th {

--- a/react-app/src/pages/dashboard/dashboard.css
+++ b/react-app/src/pages/dashboard/dashboard.css
@@ -154,7 +154,7 @@
   background: #fff;
   border-radius: 8px;
   border: 1px solid #e0e0e0;
-  margin: 1rem 0;
+  padding: 1rem 0;
 }
 
 /* ── Backported from results page ────────────────────────────── */

--- a/react-app/src/pages/dashboard/dashboard.css
+++ b/react-app/src/pages/dashboard/dashboard.css
@@ -85,7 +85,7 @@
   justify-content: center;
   align-items: center;
   height: 3rem;
-  background-color: #f5f5f5;
+  background-color: #fff;
   border: 1px solid #e0e0e0;
   border-radius: 8px;
   overflow: hidden;
@@ -95,7 +95,7 @@
   width: 10vw;
   height: 100%;
   border: none;
-  background-color: #f5f5f5;
+  background-color: #fff;
   color: #14213d;
   font-size: 1rem;
   font-weight: 500;
@@ -225,32 +225,32 @@
 .dashboard--button--next {
   font-size: 1rem;
   font-weight: 500;
-  background-color: #007bff;
+  background-color: #fff;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   padding: 0.5rem;
-  color: #fff;
+  color: #14213d;
   margin-top: 0;
   width: 10rem;
   border-radius: 8px;
-  border: none;
+  border: 1px solid #e0e0e0;
   transition: background-color 0.3s ease-in-out;
 }
 
-.dashboard--button--next:hover {
-  background-color: #0069d9;
+.dashboard--button--next:hover:not(:disabled) {
+  background-color: #e8f0fe;
 }
 
 .dashboard--next--page button:disabled {
-  background-color: #f5f5f5;
-  color: #999;
+  background-color: #fff;
+  color: #bbb;
   cursor: not-allowed;
 }
 
-.dashboard--button--next:active {
-  background-color: #0056b3;
+.dashboard--button--next:active:not(:disabled) {
+  background-color: #c3d7fa;
 }
 
 .dashboard--button div {
@@ -440,7 +440,7 @@
   background-color: #007bff;
   color: #fff;
   border: none;
-  border-radius: 2px;
+  border-radius: 8px;
   font-size: 1.5rem;
   cursor: pointer;
 }

--- a/react-app/src/pages/dashboard/dashboard.css
+++ b/react-app/src/pages/dashboard/dashboard.css
@@ -154,6 +154,7 @@
   background: #fff;
   border-radius: 8px;
   border: 1px solid #e0e0e0;
+  margin: 1rem 0;
 }
 
 /* ── Backported from results page ────────────────────────────── */

--- a/react-app/src/pages/dashboard/dashboard.css
+++ b/react-app/src/pages/dashboard/dashboard.css
@@ -39,6 +39,7 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  gap: 0.5rem;
   margin: 0 0 1rem 0;
 }
 
@@ -156,16 +157,6 @@
 }
 
 /* ── Backported from results page ────────────────────────────── */
-
-.dashboard--kind-badge {
-  background: #14213d;
-  color: #fff;
-  border-radius: 4px;
-  padding: 0.15rem 0.5rem;
-  font-size: 0.8rem;
-  font-weight: 600;
-  white-space: nowrap;
-}
 
 .dashboard--completion {
   display: flex;
@@ -392,7 +383,7 @@
   width: 100%;
   display: flex;
   flex-direction: row;
-  justify-content: flex-start;
+  justify-content: flex-end;
   align-items: center;
   margin-top: 1rem;
 }

--- a/react-app/src/pages/dashboard/dashboard.css
+++ b/react-app/src/pages/dashboard/dashboard.css
@@ -66,7 +66,7 @@
   flex-direction: column;
   justify-content: space-evenly;
   align-items: center;
-  border-radius: 2px;
+  border-radius: 8px;
 }
 
 .dashboard--table-header {
@@ -85,7 +85,9 @@
   align-items: center;
   height: 3rem;
   background-color: #f5f5f5;
-  border: 2px solid #e0e0e0;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  overflow: hidden;
 }
 
 .filter-button {
@@ -120,7 +122,9 @@
 .dashboard--overview--content div {
   height: 100%;
   width: 100%;
-  border: 2px solid #b8bcc5;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background: #fff;
   padding: 2rem;
   margin: 0.1rem;
 }
@@ -146,10 +150,9 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  background-color: #f5f5f5;
-  border-radius: 2px;
-
-  border: 2px solid #e0e0e0;
+  background: #fff;
+  border-radius: 8px;
+  border: 1px solid #e0e0e0;
 }
 
 /* ── Backported from results page ────────────────────────────── */
@@ -213,12 +216,11 @@
   justify-content: center;
   align-items: center;
   padding: 2rem;
-  color: #fff; /* Set font color to white */
+  color: #fff;
   margin-top: 0;
-  border-radius: 2px;
-
+  border-radius: 8px;
+  border: none;
   transition: background-color 0.3s ease-in-out;
-  border: 2px solid #e0e0e0;
 }
 
 .dashboard--button:hover {
@@ -241,10 +243,9 @@
   color: #fff;
   margin-top: 0;
   width: 10rem;
-  border-radius: 2px;
-
+  border-radius: 8px;
+  border: none;
   transition: background-color 0.3s ease-in-out;
-  border: 2px solid #e0e0e0;
 }
 
 .dashboard--button--next:hover {
@@ -279,8 +280,9 @@
   flex-direction: row;
   justify-content: space-evenly;
   align-items: center;
-  border: 2px solid #b8bcc5;
-  background-color: #f5f5f5;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background: #fff;
 }
 
 .question {
@@ -304,11 +306,11 @@
 
 .dashboard--question--table {
   width: 100%;
-  background-color: #f5f5f5;
-  border-radius: 2px;
-
-  overflow-x: auto; /* Enable horizontal scrolling on smaller screens */
-  border: 2px solid #e0e0e0;
+  background: #fff;
+  border-radius: 8px;
+  border: 1px solid #e0e0e0;
+  border-collapse: separate;
+  border-spacing: 0;
 }
 
 .dashboard--question--table::-webkit-scrollbar {
@@ -402,8 +404,8 @@
 
 .create-container {
   background-color: #fff;
-  border: 2px solid #b8bcc5;
-  border-radius: 2px;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
   padding: 1rem 4rem 3rem 4rem;
   width: min(900px, 90vw);
   box-sizing: border-box;
@@ -621,7 +623,8 @@
 
 .add-participants-container {
   background-color: #fff;
-  border: 2px solid #b8bcc5;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
   width: min(500px, 90vw);
   height: auto;
   max-height: 90vh;
@@ -809,8 +812,8 @@ input[type="file"][value]:not([value=""]) {
 
 .template-manager {
   background-color: #fff;
-  border: 2px solid #b8bcc5;
-  border-radius: 2px;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
   padding: 1.5rem 2rem 2rem;
   width: min(860px, 95vw);
   max-height: 90vh;


### PR DESCRIPTION
## Summary

- **Results column always visible**: removed `no-mobile no-tablet` classes from the Results header/cell in `DashboardTable` — the column links to the per-survey results route and should be reachable on all screen sizes
- **Backport styles from Results page**: added a dark pill badge for the survey type label and a visual progress bar next to the completion percentage in the dashboard table, matching the look and feel of `ResultsView`
- **PieChart checkbox title fix**: the `L2E` fixture surveys only had 2 entries in `questions` (for the two Likert slots), so the checkbox slot fell back to its template placeholder text; added the missing third entry for both fixture surveys to match production behaviour

Closes #111